### PR TITLE
fix(content): remove unimplemented features from user-facing pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - PDFUploaderController, PDFViewerController, EditorController
 - TypeScript interfaces for service layer (IPDFService, IPDFLoader, IPDFRenderer)
 - Custom event system for component communication (`pdf-loaded` event)
-- Single PDF editor page at `/app` with all 8 core operations: merge, split, reorder, rotate, delete, compress, watermark, convert
+- Single PDF editor page at `/app` with 5 core operations: merge, split, reorder, rotate, delete
 - PDFOperationsService for building PDFs using pdf-lib
 - Download utility for triggering file downloads
 - Astro View Transitions for SPA-like page navigation
@@ -61,6 +61,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Removed compress, watermark, convert, and undo from features page, FAQ, and changelog — these operations are not yet implemented (closes #17)
 - Race condition in drag-drop reorder: `handleDrop` now awaits `renderAllPages()` so thumbnails always settle in the correct order when pages are dragged rapidly
 - Concurrent render interleaving on large PDFs: `renderAllPages()` now uses a generation counter to abort superseded render cycles, preventing old and new renders from writing to the same container simultaneously
 - Encrypted PDFs failing silently instead of showing user-facing feedback

--- a/src/content/changelog/v1-0.md
+++ b/src/content/changelog/v1-0.md
@@ -2,7 +2,6 @@
 version: 'v1.0'
 date: 'February 2026'
 changes:
-  - Added watermark and convert operations
   - 'New SEO pages: features, about, blog, privacy, terms, FAQ'
   - Shared navigation and footer components
   - Mobile rendering fixes for feature grid

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -44,7 +44,7 @@ const questions = [
   {
     num: '08',
     q: 'What PDF operations are supported?',
-    a: 'Pasta supports merge, split, reorder, rotate, delete, compress, watermark, and convert operations. All operations are performed client-side.',
+    a: 'Pasta supports merge, split, reorder, rotate, and delete operations. All operations are performed client-side.',
   },
 ];
 ---

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -42,32 +42,14 @@ const features = [
     num: '05',
     title: 'Delete',
     desc: 'Remove unwanted pages cleanly from any PDF.',
-    details: ['Click to select pages', 'Bulk deletion', 'Undo support'],
-  },
-  {
-    num: '06',
-    title: 'Compress',
-    desc: 'Reduce PDF file size for easier sharing.',
-    details: ['Optimized output', 'Quality preservation', 'Fast processing'],
-  },
-  {
-    num: '07',
-    title: 'Watermark',
-    desc: 'Add text or image watermarks to your documents.',
-    details: ['Custom text watermarks', 'Adjustable opacity', 'Position control'],
-  },
-  {
-    num: '08',
-    title: 'Convert',
-    desc: 'Convert between PDF and image formats.',
-    details: ['PDF to images', 'Images to PDF', 'Multiple format support'],
+    details: ['Click to select pages', 'Bulk deletion'],
   },
 ];
 ---
 
 <Layout
   title="Features — Pasta"
-  description="Merge, split, reorder, rotate, delete, compress, watermark, and convert PDFs. Eight powerful operations, all running client-side in your browser."
+  description="Merge, split, reorder, rotate, and delete PDFs. Five powerful operations, all running client-side in your browser."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
     <Nav base={base} currentPage="features" />


### PR DESCRIPTION
## Summary

Closes #17.

- Removed feature cards for Compress, Watermark, and Convert from `features.astro` — none of these operations are implemented in the editor
- Removed "Undo support" bullet from the Delete feature card — no undo/redo system exists
- Updated the features page meta description from "Eight powerful operations" to "Five powerful operations"
- Updated the FAQ answer for "What PDF operations are supported?" to list only the 5 implemented operations
- Removed "Added watermark and convert operations" from the v1.0 changelog entry
- Updated `CHANGELOG.md` to reflect the corrected operation count

## Test plan

- [ ] Visit `/features` — confirm only Merge, Split, Reorder, Rotate, Delete are listed; no Compress, Watermark, Convert, or Undo
- [ ] Visit `/faq` — confirm question 08 answer lists only the 5 implemented operations
- [ ] Visit `/changelog` — confirm no mention of watermark or convert as shipped features

🤖 Generated with [Claude Code](https://claude.com/claude-code)