### PR TITLE
docs: rewrite README with Pasta-specific content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Removed compress, watermark, convert, and undo from features page, FAQ, and changelog — these operations are not yet implemented (closes #17)
+- Rewrote README to replace Astro starter kit template with Pasta-specific content (closes #18)
 - Race condition in drag-drop reorder: `handleDrop` now awaits `renderAllPages()` so thumbnails always settle in the correct order when pages are dragged rapidly
 - Concurrent render interleaving on large PDFs: `renderAllPages()` now uses a generation counter to abort superseded render cycles, preventing old and new renders from writing to the same container simultaneously
 - Encrypted PDFs failing silently instead of showing user-facing feedback

--- a/README.md
+++ b/README.md
@@ -1,43 +1,21 @@
-# Astro Starter Kit: Minimal
+# Pasta
+
+A fully client-side PDF manipulation tool. All operations run entirely in your browser using pdf-lib — no files are ever uploaded to a server.
+
+**Live**: https://abijith-suresh.github.io/pasta/
+
+## Tech Stack
+
+- [Astro 5.x](https://astro.build) — static site framework
+- [pdf-lib](https://pdf-lib.js.org) — client-side PDF manipulation
+- [Tailwind CSS v4](https://tailwindcss.com) — utility-first styling
+- [Bun](https://bun.sh) — package manager and dev tooling
+
+## Getting Started
 
 ```sh
-bun create astro@latest -- --template minimal
+bun install   # install dependencies
+bun dev       # start dev server at localhost:4321
+bun run build # build for production
+bun run preview # preview production build locally
 ```
-
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
-
-## 🚀 Project Structure
-
-Inside of your Astro project, you'll see the following folders and files:
-
-```text
-/
-├── public/
-├── src/
-│   └── pages/
-│       └── index.astro
-└── package.json
-```
-
-Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page is exposed as a route based on its file name.
-
-There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
-
-Any static assets, like images, can be placed in the `public/` directory.
-
-## 🧞 Commands
-
-All commands are run from the root of the project, from a terminal:
-
-| Command               | Action                                           |
-| :-------------------- | :----------------------------------------------- |
-| `bun install`         | Installs dependencies                            |
-| `bun dev`             | Starts local dev server at `localhost:4321`      |
-| `bun build`           | Build your production site to `./dist/`          |
-| `bun preview`         | Preview your build locally, before deploying     |
-| `bun astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `bun astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).


### PR DESCRIPTION
## Summary

Closes #18.

- Replaced the default Astro starter kit template (`Astro Starter Kit: Minimal`, "Seasoned astronaut?", Discord invite, etc.) with Pasta-specific content
- README now covers: what Pasta is, live URL, tech stack, and getting-started commands

## Test plan

- [ ] README contains no references to the Astro starter template
- [ ] All commands listed (`bun install`, `bun dev`, `bun run build`, `bun run preview`) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)