### PR TITLE
fix(editor): move service cleanup to constructor to fix encrypted PDF rendering

### DIFF
--- a/src/controllers/editor-controller.ts
+++ b/src/controllers/editor-controller.ts
@@ -54,6 +54,12 @@ export class EditorController {
       throw new Error('Required DOM elements not found for editor');
     }
 
+    // Clear singleton service state from any previous session up-front, before
+    // any PDF loading begins. Doing this here (not in handlePDFLoaded) ensures
+    // the password stored by loadPDFWithPassword is never wiped mid-session.
+    this.pdfService.clearPasswordRegistry();
+    this.operationsService.clearCache();
+
     this.attachEventListeners();
   }
 
@@ -91,11 +97,6 @@ export class EditorController {
 
   private handlePDFLoaded(detail: PDFLoadedEvent): void {
     const { pageCount, file } = detail;
-
-    // Reset singleton service state accumulated from any previous session
-    // (SPA navigation creates a new controller but reuses the same singletons).
-    this.pdfService.clearPasswordRegistry();
-    this.operationsService.clearCache();
 
     this.pages = [];
     this.selectedIndices.clear();


### PR DESCRIPTION
## Root cause

PR #48 introduced `clearPasswordRegistry()` and `clearCache()` calls inside `handlePDFLoaded()`. The problem is the call order:

1. User uploads an encrypted PDF
2. `loadPDFWithPassword(file, password)` succeeds → **password is stored** in `passwordRegistry`
3. `dispatchLoadedEvent()` fires `pdf-loaded`
4. `handlePDFLoaded()` runs → **`clearPasswordRegistry()` wipes the password just stored**
5. `IntersectionObserver` fires `renderPageCanvas` for visible thumbnails
6. `getPassword(file)` returns `undefined` → falls back to `loadPDF()` → throws `PDFPasswordRequiredError`
7. Every thumbnail shows `(Error)` in the label

## Fix

Move both cleanup calls to the **constructor**, which runs at the start of each SPA page load before any PDF is touched. This is the correct session boundary — singleton state from the previous session is cleared before anything new is loaded, not after.

```diff
  constructor(...) {
    ...
+   this.pdfService.clearPasswordRegistry();
+   this.operationsService.clearCache();
    this.attachEventListeners();
  }

  private handlePDFLoaded(detail) {
-   this.pdfService.clearPasswordRegistry();
-   this.operationsService.clearCache();
    this.pages = [];
    ...
  }
```

## Test plan

- [ ] Upload a password-protected PDF → enter correct password → all thumbnails render correctly (no `(Error)` labels)
- [ ] Upload a normal PDF → editor loads as expected
- [ ] Navigate away and back (SPA transition) → load a new PDF → no stale passwords or cached docs from the previous session

🤖 Generated with [Claude Code](https://claude.com/claude-code)