### PR TITLE
chore: finalize v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-02-27
+
 ### Added
 
 - Pasta brand favicon (dark background, white "P", red accent bar) replacing the default Astro icon

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "pasta",
   "type": "module",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "scripts": {
     "dev": "astro dev",
     "build": "astro build",

--- a/src/content/changelog/v1-0.md
+++ b/src/content/changelog/v1-0.md
@@ -2,8 +2,13 @@
 version: "v1.0"
 date: "February 2026"
 changes:
-  - "New SEO pages: features, about, privacy, terms, FAQ"
-  - Shared navigation and footer components
-  - Mobile rendering fixes for feature grid
-  - Tailwind CSS theme tokens for design consistency
+  - "Five core operations — merge, split, reorder, rotate, and delete — all running entirely in the browser via pdf-lib"
+  - "Encrypted PDF support: owner-password PDFs load silently; user-password PDFs trigger a Swiss modernist password modal with retry and cancel"
+  - "Lazy-load page thumbnails using IntersectionObserver — eliminates browser freeze on large documents"
+  - "Drag-and-drop page reorder with directional insertion bar showing exactly where a page will land"
+  - "Full keyboard accessibility: ARIA roles on page grid, toolbar, and upload zone; focus trap in password modal"
+  - "Swiss modernist design with Bebas Neue display type, Work Sans body, and a red accent bar"
+  - "Build-time OG image generation (1200×630) for all pages using satori + resvg"
+  - "SEO pages: features, about, privacy policy, terms of service, and FAQ"
+  - "Astro View Transitions for SPA-like navigation with scroll-triggered entrance animations"
 ---


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `0.0.1` → `1.0.0`
- Moves all `[Unreleased]` entries in `CHANGELOG.md` to a dated `[1.0.0] — 2026-02-27` section; leaves a fresh empty `[Unreleased]` at the top
- Rewrites `src/content/changelog/v1-0.md` with a complete, accurate user-facing summary of everything that shipped in v1 (replaces the 4-item placeholder)

Closes #64

## Test plan

- [ ] `package.json` version field reads `1.0.0`
- [ ] `CHANGELOG.md` has an empty `[Unreleased]` section at the top and a dated `[1.0.0]` section below
- [ ] `/changelog` page renders the v1.0 entry with all 9 changes listed correctly
- [ ] `bun run build` completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)