### PR TITLE
ci: add node setup for Astro compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:


### PR DESCRIPTION
## Summary

Add `actions/setup-node@v5` with Node 24 to the CI workflow for Astro/tooling runtime compatibility.

### What changed
- Added Node.js 24 setup step to `.github/workflows/ci.yml`
- Node setup is placed **before** Bun setup

### What did NOT change
- Bun remains the **package manager**, **lockfile manager**, and **script runner**
- All existing Bun steps preserved (`bun install --frozen-lockfile`, `bun run verify`, etc.)
- No changes to `package.json`, Dependabot config, docs, or release workflows

### Checklist
- [x] Only `.github/workflows/ci.yml` was modified
- [x] Bun remains the sole package manager and script runner
- [x] Node 24 is added solely for Astro/tooling runtime compatibility
- [x] Local verification passed (`bun run verify` — type-check, lint, format, test, build all green)
- [x] Existing downstream checks preserved (Playwright E2E, dependency review)