### PR TITLE
docs: align README and contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 
 ## Stack
 
-- Astro 5
+- Astro 6
 - SolidJS editor UI
 - Tailwind CSS v4
 - TypeScript
@@ -24,11 +24,13 @@
 
 ## Project Map
 
-- `src/components/app/`: editor UI
-- `src/controllers/`: DOM orchestration and interaction wiring
+- `src/components/app/`: editor UI, tiles, canvases, sidebar, and uploader
+- `src/controllers/`: editor page-state helpers and orchestration utilities
 - `src/services/`: PDF load, render, and manipulation logic
-- `src/utils/`: download, password prompt, transitions, and helpers
+- `src/pages/`: marketing, legal, editor, and OG routes
+- `src/utils/`: download, password prompt, toast, transitions, and helpers
 - `tests/e2e/`: Playwright coverage for core editor flows
+- `tests/fixtures/`: sample PDFs used by browser tests
 
 ## Hard Rules
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quire
 
-Quire is a fully client-side PDF editor for the five tasks people reach for most: merge, extract, reorder, rotate, and delete. Every operation runs in your browser with `pdf-lib` and `pdf.js`, so your files never leave your device.
+Quire is a fully client-side PDF editor for the core tasks people reach for most: merge, extract, reorder, rotate, delete, and unlock. Every operation runs in your browser with `pdf-lib` and `pdf.js`, so your files never leave your device.
 
 ## Product Scope
 
@@ -10,10 +10,11 @@ Quire is a fully client-side PDF editor for the five tasks people reach for most
 - Rotate individual pages or selections in 90 degree steps
 - Mark pages for deletion before export
 - Unlock password-protected PDFs with an in-browser prompt
+- Render page thumbnails locally with pdf.js for inspection before export
 
 ## Stack
 
-- [Astro 5](https://astro.build) for the site shell and content pages
+- [Astro 6](https://astro.build) for the site shell and content pages
 - [SolidJS](https://www.solidjs.com/) for the editor interface
 - [Tailwind CSS v4](https://tailwindcss.com) for styling
 - [pdf-lib](https://pdf-lib.js.org) and [pdf.js](https://mozilla.github.io/pdf.js/) for PDF processing/rendering
@@ -33,6 +34,12 @@ The app runs at `http://localhost:4321` by default.
 ## Quality Checks
 
 ```sh
+bun run verify
+```
+
+Or run the individual steps:
+
+```sh
 bun run type-check
 bun run lint
 bun run format:check
@@ -45,13 +52,14 @@ bun run build
 
 ```text
 src/
-  components/app/      Solid editor UI
-  components/shared/   Shared site chrome
-  content/changelog/   Changelog content collection
-  layouts/             Shared page layout and SEO
+  components/app/      Solid editor UI and page tiles/canvases
+  components/shared/   Shared marketing-site chrome
+  controllers/         Editor page-state helpers and orchestration logic
+  fonts/               Self-hosted application assets
+  layouts/             Shared page layout and SEO tags
   pages/               Marketing, legal, editor, and OG routes
-  services/            PDF load/render/build services
-  styles/              Global design tokens and animations
+  services/            PDF load, render, and build services
+  styles/              Global styles and motion primitives
   utils/               Download, password, toast, and transition helpers
 tests/
   e2e/                 Playwright coverage for the core editor flow
@@ -68,4 +76,5 @@ tests/
 
 - Open an issue for bugs, polish work, or roadmap ideas
 - Keep changes atomic and follow Conventional Commits
-- Run lint, unit tests, E2E, and build checks before opening a PR
+- Preserve the browser-only privacy model: do not add uploads or server-side PDF handling
+- Run `bun run verify` before opening a PR, and run `bun run test:e2e` when changing core editor workflows


### PR DESCRIPTION
## Summary
Refresh contributor-facing documentation so it matches the current Quire app, stack, and verification flow.

## Changes
- update README product scope, stack version, verification command, and project structure
- align AGENTS.md with Astro 6 and the current repository layout

## Testing
- [x] bun run verify
- [ ] Review docs wording for any stale product claims

## References
- Ticket/Issue: Fixes #65