### PR TITLE
fix: replace stale editor branding

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -385,7 +385,7 @@ export default function Editor() {
             href={base}
             class="font-['Bebas_Neue',sans-serif] text-2xl tracking-wide text-white no-underline"
           >
-            Pasta
+            Quire
           </a>
           <span class="w-px h-6 bg-[#555] mx-5" />
           <Show when={phase() === "edit"}>


### PR DESCRIPTION
## Summary
Replace the stale Pasta brand name in the runtime editor chrome so the live product matches the Quire branding used everywhere else.

## Changes
- update the editor header brand label from Pasta to Quire
- confirm no other non-historical runtime Pasta references remain in the repository

## Testing
- [x] bun run verify
- [ ] Manually confirm the editor header copy and spacing still look correct on desktop and mobile

## References
- Ticket/Issue: Fixes #109