### PR TITLE
chore: self-host app fonts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,8 @@
       "name": "pasta",
       "dependencies": {
         "@astrojs/solid-js": "^6.0.0",
+        "@fontsource/bebas-neue": "^5.2.7",
+        "@fontsource/work-sans": "^5.2.8",
         "@resvg/resvg-js": "^2.6.2",
         "@tailwindcss/typography": "^0.5.19",
         "astro": "^6.2.1",
@@ -251,6 +253,10 @@
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
     "@exodus/bytes": ["@exodus/bytes@1.15.0", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ=="],
+
+    "@fontsource/bebas-neue": ["@fontsource/bebas-neue@5.2.7", "", {}, "sha512-DsmBrmq55d9BCU0mt4DT4RZDdH8vhWRKEUOfbuNB1EEjMuwbtFvM8N+3gIlkYSFbsb10P8Q19BV5OdpMu2h0fA=="],
+
+    "@fontsource/work-sans": ["@fontsource/work-sans@5.2.8", "", {}, "sha512-6LaHjVVgts+rnrcqvEkP2+iUB/jw1oDSYsGO0+TltAhnWki9Hnf/UGpgMQh2jcm0GEH8VqCPnq4PpmHLFzxXtQ=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
   },
   "dependencies": {
     "@astrojs/solid-js": "^6.0.0",
+    "@fontsource/bebas-neue": "^5.2.7",
+    "@fontsource/work-sans": "^5.2.8",
     "@resvg/resvg-js": "^2.6.2",
     "@tailwindcss/typography": "^0.5.19",
     "astro": "^6.2.1",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -24,12 +24,6 @@ const resolvedOgImage = ogImage ?? `${siteOrigin}${base}og/${slug}.png`;
     <link rel="apple-touch-icon" href={`${base}apple-touch-icon.png`} />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="generator" content={Astro.generator} />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Work+Sans:wght@300;400;500;600&display=swap"
-      rel="stylesheet"
-    />
     <link rel="canonical" href={canonicalURL} />
     {description && <meta name="description" content={description} />}
     <meta property="og:type" content="website" />

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -28,7 +28,7 @@ const sections = [
     num: "04",
     title: "No Third-Party Services",
     content:
-      "We do not integrate with any third-party analytics, advertising, or tracking services. The only external resources loaded are Google Fonts for typography.",
+      "We do not integrate with any third-party analytics, advertising, or tracking services. Runtime assets, including typography, are bundled with the app instead of being fetched from third-party CDNs.",
   },
   {
     num: "05",

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,3 +1,8 @@
+@import "@fontsource/bebas-neue/400.css";
+@import "@fontsource/work-sans/300.css";
+@import "@fontsource/work-sans/400.css";
+@import "@fontsource/work-sans/500.css";
+@import "@fontsource/work-sans/600.css";
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 


### PR DESCRIPTION
## Summary
Self-host the app fonts through bundled font assets so Quire no longer depends on runtime requests to Google Fonts.

## Changes
- add bundled Bebas Neue and Work Sans font packages and import their local CSS in the global stylesheet
- remove the Google Fonts links from the shared layout and update the privacy page copy to reflect bundled typography assets

## Testing
- [x] bun run verify
- [ ] Manually compare typography and spacing on the marketing pages and editor against the current production design

## References
- Ticket/Issue: Fixes #110