### PR TITLE
feat: add text watermark downloads

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -49,6 +49,7 @@ export default function Editor() {
   const [dragOverTarget, setDragOverTarget] = createSignal<DragOverTarget | null>(null);
   const [operation, setOperation] = createSignal<EditorOperation>("idle");
   const [statusMessage, setStatusMessage] = createSignal("Drop a PDF to begin");
+  const [watermarkText, setWatermarkText] = createSignal("");
   const [toasts, setToasts] = createSignal<Toast[]>([]);
 
   onMount(() => {
@@ -165,6 +166,7 @@ export default function Editor() {
   function handleFileLoaded(file: File, pageCount: number): void {
     setPages(createPageStates(file, pageCount));
     setSelectedIndices(new Set<number>());
+    setWatermarkText("");
     setPhase("edit");
     setReadyStatus();
     dispatchToast(`${file.name} loaded with ${formatPageCount(pageCount)}.`, "success");
@@ -282,6 +284,30 @@ export default function Editor() {
     } catch (err) {
       console.error("Failed to build PDF:", err);
       dispatchToast("Failed to build the PDF.", "error");
+    } finally {
+      setReadyStatus();
+    }
+  }
+
+  async function handleWatermarkDownload(): Promise<void> {
+    if (isBusy()) return;
+
+    const text = watermarkText().trim();
+    if (!text) {
+      dispatchToast("Enter watermark text to continue.", "error");
+      return;
+    }
+
+    setOperation("building");
+    setStatusMessage("Applying watermark...");
+
+    try {
+      const result = await pdfOperationsService.addWatermark(pages, text);
+      downloadPDF(result);
+      dispatchToast("Watermarked PDF download started.", "success");
+    } catch (err) {
+      console.error("Failed to apply watermark:", err);
+      dispatchToast("Failed to apply watermark.", "error");
     } finally {
       setReadyStatus();
     }
@@ -423,6 +449,9 @@ export default function Editor() {
             <EditorSidebar
               busy={isBusy()}
               selectedCount={selectedIndices().size}
+              watermarkText={watermarkText()}
+              onWatermarkTextChange={setWatermarkText}
+              onWatermarkDownload={handleWatermarkDownload}
               onSelectAll={handleSelectAll}
               onRotate={handleRotateSelected}
               onDelete={handleDeleteSelected}

--- a/src/components/app/EditorSidebar.tsx
+++ b/src/components/app/EditorSidebar.tsx
@@ -1,6 +1,9 @@
 interface Props {
   busy: boolean;
   selectedCount: number;
+  watermarkText: string;
+  onWatermarkTextChange: (value: string) => void;
+  onWatermarkDownload: () => void;
   onSelectAll: () => void;
   onRotate: () => void;
   onDelete: () => void;
@@ -92,16 +95,38 @@ export default function EditorSidebar(props: Props) {
       </div>
 
       {/* Export — pinned to bottom */}
-      <div class="p-4 border-t border-[#ddd] flex-shrink-0">
-        <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
-        <button
-          data-testid="editor-download-button"
-          onClick={props.onDownload}
-          disabled={props.busy}
-          class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {props.busy ? "Working..." : "Download"}
-        </button>
+      <div class="p-4 border-t border-[#ddd] flex-shrink-0 space-y-4">
+        <div>
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Watermark</p>
+          <input
+            data-testid="editor-watermark-input"
+            type="text"
+            value={props.watermarkText}
+            placeholder="CONFIDENTIAL"
+            disabled={props.busy}
+            onInput={(e) => props.onWatermarkTextChange(e.currentTarget.value)}
+            class="w-full border border-[#ddd] px-3 py-2 text-xs tracking-[0.08em] uppercase text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+          />
+          <button
+            data-testid="editor-watermark-button"
+            onClick={props.onWatermarkDownload}
+            disabled={props.busy}
+            class="mt-3 w-full border border-[#111] text-[#111] text-[11px] uppercase tracking-[0.15em] font-semibold py-3 bg-transparent cursor-pointer hover:bg-[#111] hover:text-white transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Apply Watermark & Download
+          </button>
+        </div>
+        <div>
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
+          <button
+            data-testid="editor-download-button"
+            onClick={props.onDownload}
+            disabled={props.busy}
+            class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {props.busy ? "Working..." : "Download"}
+          </button>
+        </div>
       </div>
     </aside>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,5 +19,8 @@ export const OUTPUT_FILENAME = "quire-output.pdf";
 /** Default file name when extracting a page subset */
 export const EXTRACT_FILENAME = "quire-extract.pdf";
 
+/** Default file name when downloading a watermarked PDF */
+export const WATERMARK_FILENAME = "quire-watermarked.pdf";
+
 /** Title shown in the password prompt modal for encrypted PDFs */
 export const PASSWORD_MODAL_TITLE = "PASSWORD REQUIRED";

--- a/src/services/__tests__/pdf-operations-service.test.ts
+++ b/src/services/__tests__/pdf-operations-service.test.ts
@@ -10,9 +10,16 @@ const createMockPage = (overrides: Partial<PageState> = {}): PageState => ({
   ...overrides,
 });
 
+const mockCopiedPage = {
+  setRotation: vi.fn(),
+  getSize: vi.fn().mockReturnValue({ width: 600, height: 800 }),
+  drawText: vi.fn(),
+};
+
 const mockPDFDoc = {
-  copyPages: vi.fn().mockResolvedValue([{ setRotation: vi.fn() }]),
+  copyPages: vi.fn().mockResolvedValue([mockCopiedPage]),
   addPage: vi.fn(),
+  embedFont: vi.fn().mockResolvedValue({ widthOfTextAtSize: vi.fn().mockReturnValue(240) }),
   save: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
   getPageCount: vi.fn().mockReturnValue(1),
 };
@@ -27,7 +34,9 @@ vi.mock("pdf-lib", () => ({
     load: mockPDFDocument.load,
     create: mockPDFDocument.create,
   },
+  StandardFonts: { Helvetica: "Helvetica" },
   degrees: vi.fn((deg) => deg),
+  grayscale: vi.fn((value) => value),
 }));
 
 describe("PDFOperationsService", () => {
@@ -157,6 +166,28 @@ describe("PDFOperationsService", () => {
 
       await expect(service.buildPDFFromSubset(pages, [])).rejects.toThrow(
         "No pages selected for extraction"
+      );
+    });
+  });
+
+  describe("addWatermark", () => {
+    it("applies a watermark to each active page", async () => {
+      const service = new PDFOperationsService();
+      const result = await service.addWatermark([createMockPage()], "CONFIDENTIAL");
+
+      expect(mockPDFDoc.embedFont).toHaveBeenCalledWith("Helvetica");
+      expect(mockCopiedPage.drawText).toHaveBeenCalledWith(
+        "CONFIDENTIAL",
+        expect.objectContaining({ opacity: 0.5, rotate: 45 })
+      );
+      expect(result.suggestedFileName).toBe("quire-watermarked.pdf");
+    });
+
+    it("rejects blank watermark text", async () => {
+      const service = new PDFOperationsService();
+
+      await expect(service.addWatermark([createMockPage()], "   ")).rejects.toThrow(
+        "Watermark text is required"
       );
     });
   });

--- a/src/services/pdf-operations-service.ts
+++ b/src/services/pdf-operations-service.ts
@@ -1,5 +1,5 @@
-import { PDFDocument, degrees } from "pdf-lib";
-import { EXTRACT_FILENAME, OUTPUT_FILENAME } from "../constants";
+import { PDFDocument, StandardFonts, degrees, grayscale } from "pdf-lib";
+import { EXTRACT_FILENAME, OUTPUT_FILENAME, WATERMARK_FILENAME } from "../constants";
 import type {
   PageState,
   PDFOperationResult,
@@ -67,6 +67,61 @@ export class PDFOperationsService implements IPDFOperationsService {
       EXTRACT_FILENAME,
       onProgress
     );
+  }
+
+  /**
+   * Builds a new PDF with a centered diagonal watermark applied to each active page.
+   *
+   * @param pages - The current editor page state to watermark.
+   * @param text - The watermark text to apply.
+   * @returns The generated PDF bytes and a suggested download filename.
+   * @throws {Error} When there are no active pages or the watermark text is blank.
+   */
+  async addWatermark(pages: PageState[], text: string): Promise<PDFOperationResult> {
+    const trimmedText = text.trim();
+    if (!trimmedText) {
+      throw new Error("Watermark text is required");
+    }
+
+    const activePages = pages.filter((page) => !page.markedForDeletion);
+    if (activePages.length === 0) {
+      throw new Error("No pages to include in the PDF");
+    }
+
+    const outputDoc = await PDFDocument.create();
+    const font = await outputDoc.embedFont(StandardFonts.Helvetica);
+
+    for (const page of activePages) {
+      const sourceDoc = await this.getOrLoadSourceDoc(page.sourceFile);
+      const [copiedPage] = await outputDoc.copyPages(sourceDoc, [page.sourcePageNumber - 1]);
+
+      if (page.rotation !== 0) {
+        copiedPage.setRotation(degrees(page.rotation));
+      }
+
+      const { width, height } = copiedPage.getSize();
+      const fontSize = Math.min(width, height) / 6;
+      const textWidth = font.widthOfTextAtSize(trimmedText, fontSize);
+
+      copiedPage.drawText(trimmedText, {
+        x: (width - textWidth) / 2,
+        y: height / 2,
+        size: fontSize,
+        font,
+        color: grayscale(0.65),
+        opacity: 0.5,
+        rotate: degrees(45),
+      });
+
+      outputDoc.addPage(copiedPage);
+    }
+
+    const data = await outputDoc.save();
+
+    return {
+      data: new Uint8Array(data),
+      suggestedFileName: WATERMARK_FILENAME,
+    };
   }
 
   private async buildOutputFromPages(

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -66,6 +66,16 @@ export interface IPDFOperationsService {
   ): Promise<PDFOperationResult>;
 
   /**
+   * Builds a new PDF with a text watermark applied to each active page.
+   *
+   * @param pages - The current editor page state to watermark.
+   * @param text - The watermark text to apply.
+   * @returns The generated PDF bytes and a suggested download filename.
+   * @throws {Error} When there are no active pages or the watermark text is blank.
+   */
+  addWatermark(pages: PageState[], text: string): Promise<PDFOperationResult>;
+
+  /**
    * Clears any cached source documents held for the current editor session.
    *
    * @returns Nothing.

--- a/tests/e2e/core-app.spec.ts
+++ b/tests/e2e/core-app.spec.ts
@@ -65,6 +65,22 @@ test("adds another PDF to the current session", async ({ page }) => {
   await expect(page.getByTestId("editor-toast").last()).toContainText("Added 2 pages");
 });
 
+test("downloads a watermarked PDF", async ({ page }) => {
+  await page.goto("/app");
+  await uploadPdf(page, samplePdf);
+  await waitForEditorReady(page);
+
+  await page.getByTestId("editor-watermark-input").fill("CONFIDENTIAL");
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByTestId("editor-watermark-button").click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toBe("quire-watermarked.pdf");
+  await expect(page.getByTestId("editor-toast").last()).toContainText(
+    "Watermarked PDF download started."
+  );
+});
+
 test("prompts for encrypted PDFs and accepts the correct password", async ({ page }) => {
   await page.goto("/app");
   await uploadPdf(page, encryptedPdf);


### PR DESCRIPTION
## Summary
Add a text-watermark export flow so users can stamp a diagonal watermark onto every active page before downloading.

## Changes
- add a watermark operation in the PDF operations service with unit coverage for the watermark rendering behavior
- expose a watermark text field and dedicated download action in the editor sidebar, plus end-to-end coverage for the download flow

## Testing
- [x] bun run verify
- [ ] Manually validate watermark appearance, text sizing, and sidebar behavior in the browser

## References
- Ticket/Issue: Fixes #24