### PR TITLE
feat: polish editor busy states

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -400,6 +400,12 @@ export default function Editor() {
             <span class="text-sm text-[#888]">{selectedIndices().size} selected</span>
             <span class="w-px h-6 bg-[#555] mx-5" />
           </Show>
+          <Show when={isBusy()}>
+            <div class="mr-4 flex items-center gap-2 rounded-full border border-[#333] bg-[#1a1a1a] px-3 py-1 text-[10px] uppercase tracking-[0.18em] text-[#ddd]">
+              <span class="h-2 w-2 animate-pulse rounded-full bg-[#ff0000]" />
+              <span>{statusMessage()}</span>
+            </div>
+          </Show>
           <a
             href={base}
             class="text-sm text-[#888] hover:text-white no-underline transition-colors"
@@ -448,6 +454,13 @@ export default function Editor() {
                 onDrop={handleDrop}
                 onDragEnd={handleDragEnd}
               />
+
+              <Show when={isBusy()}>
+                <div class="border-t border-[#ddd] bg-[#f8f8f8] px-4 py-3 text-xs text-[#555] flex items-center gap-3">
+                  <span class="h-3 w-3 animate-spin rounded-full border border-[#bbb] border-t-[#111]" />
+                  <span>{statusMessage()}</span>
+                </div>
+              </Show>
 
               {/* Mobile toolbar */}
               <div class="md:hidden border-t border-[#ddd] p-2.5 flex items-center gap-2 flex-wrap justify-center">
@@ -505,8 +518,11 @@ export default function Editor() {
                   data-testid="editor-download-button-mobile"
                   disabled={isBusy()}
                   onClick={handleDownload}
-                  class="text-[11px] uppercase tracking-wider bg-[#ff0000] text-white border-none px-4 py-1.5 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
+                  class="flex items-center gap-2 text-[11px] uppercase tracking-wider bg-[#ff0000] text-white border-none px-4 py-1.5 cursor-pointer disabled:cursor-not-allowed disabled:opacity-60"
                 >
+                  <Show when={isBusy()}>
+                    <span class="h-3 w-3 animate-spin rounded-full border border-white/50 border-t-white" />
+                  </Show>
                   {isBusy() ? "Working..." : "Download"}
                 </button>
               </div>

--- a/src/components/app/EditorSidebar.tsx
+++ b/src/components/app/EditorSidebar.tsx
@@ -1,3 +1,5 @@
+import { Show } from "solid-js";
+
 interface Props {
   busy: boolean;
   selectedCount: number;
@@ -23,11 +25,19 @@ export default function EditorSidebar(props: Props) {
             data-testid="editor-add-pdf-button"
             onClick={() => addPdfInput.click()}
             disabled={props.busy}
-            class="w-full border border-dashed border-[#ddd] hover:border-[#111] transition-colors py-6 text-center cursor-pointer bg-transparent disabled:cursor-not-allowed disabled:opacity-60"
+            class="flex w-full items-center justify-center gap-2 border border-dashed border-[#ddd] bg-transparent py-6 text-center transition-colors hover:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <span class="text-[11px] text-[#888] uppercase tracking-wider">
-              {props.busy ? "Working..." : "+ Add PDF"}
-            </span>
+            <Show
+              when={props.busy}
+              fallback={
+                <span class="text-[11px] text-[#888] uppercase tracking-wider">+ Add PDF</span>
+              }
+            >
+              <>
+                <span class="h-3 w-3 animate-spin rounded-full border border-[#bbb] border-t-[#111]" />
+                <span class="text-[11px] text-[#888] uppercase tracking-wider">Working...</span>
+              </>
+            </Show>
           </button>
           <input
             ref={addPdfInput}
@@ -98,9 +108,14 @@ export default function EditorSidebar(props: Props) {
           data-testid="editor-download-button"
           onClick={props.onDownload}
           disabled={props.busy}
-          class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          class="flex w-full items-center justify-center gap-2 border-none bg-[#ff0000] py-3 text-[11px] font-semibold uppercase tracking-[0.15em] text-white transition-colors hover:bg-[#111] disabled:cursor-not-allowed disabled:opacity-60"
         >
-          {props.busy ? "Working..." : "Download"}
+          <Show when={props.busy} fallback={<span>Download</span>}>
+            <>
+              <span class="h-3 w-3 animate-spin rounded-full border border-white/50 border-t-white" />
+              <span>Working...</span>
+            </>
+          </Show>
         </button>
       </div>
     </aside>

--- a/src/components/app/EditorUploader.tsx
+++ b/src/components/app/EditorUploader.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { Show, createSignal } from "solid-js";
 
 interface Props {
   busy: boolean;
@@ -30,7 +30,7 @@ export default function EditorUploader(props: Props) {
           tabIndex={0}
           aria-busy={props.busy}
           aria-label="Click or drag a PDF file here to upload"
-          class={`border-2 border-dashed transition-colors py-20 text-center ${
+          class={`relative overflow-hidden border-2 border-dashed transition-colors py-20 text-center ${
             props.busy
               ? "border-[#111] bg-[#f5f5f5] cursor-wait"
               : `cursor-pointer ${isDragOver() ? "border-[#111] bg-[#f5f5f5]" : "border-[#ddd] hover:border-[#111]"}`
@@ -56,6 +56,12 @@ export default function EditorUploader(props: Props) {
             handleFile(e.dataTransfer?.files[0]);
           }}
         >
+          <Show when={props.busy}>
+            <div class="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-white/80">
+              <span class="h-8 w-8 animate-spin rounded-full border-2 border-[#ddd] border-t-[#111]" />
+              <span class="text-[11px] uppercase tracking-[0.18em] text-[#555]">Processing</span>
+            </div>
+          </Show>
           <p class="font-['Bebas_Neue',sans-serif] text-4xl text-[#111] mb-2">
             {props.busy ? "Working..." : "Drop PDF here"}
           </p>


### PR DESCRIPTION
## Summary
Strengthen the visual busy-state treatment across the editor so active operations are easier to understand at a glance on both desktop and mobile.

## Changes
- add a real overlay spinner treatment to the upload drop zone during busy states
- add active-operation indicators in the header and main content area, plus spinner treatments on key sidebar and mobile export controls

## Testing
- [x] bun run verify
- [ ] Manually validate upload, add, extract, and build states on desktop and mobile layouts

## References
- Ticket/Issue: Fixes #19