### PR TITLE
feat: add PDF metadata downloads

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -1,7 +1,7 @@
 import { createSignal, For, onCleanup, onMount, Show } from "solid-js";
 import { createStore, produce } from "solid-js/store";
 import { ROTATION_STEP } from "../../constants";
-import type { PageState } from "../../types/interfaces";
+import type { PDFDocumentMetadata, PageState } from "../../types/interfaces";
 import { PDFPasswordRequiredError } from "../../types/interfaces";
 import { pdfService } from "../../services/pdf-service";
 import { pdfOperationsService } from "../../services/pdf-operations-service";
@@ -37,6 +37,13 @@ interface Toast {
   tone: ToastTone;
 }
 
+const EMPTY_METADATA: PDFDocumentMetadata = {
+  title: "",
+  author: "",
+  subject: "",
+  keywords: "",
+};
+
 export default function Editor() {
   const base = import.meta.env.BASE_URL;
   let nextToastId = 0;
@@ -49,6 +56,10 @@ export default function Editor() {
   const [dragOverTarget, setDragOverTarget] = createSignal<DragOverTarget | null>(null);
   const [operation, setOperation] = createSignal<EditorOperation>("idle");
   const [statusMessage, setStatusMessage] = createSignal("Drop a PDF to begin");
+  const [sourceMetadata, setSourceMetadata] = createStore<PDFDocumentMetadata>({
+    ...EMPTY_METADATA,
+  });
+  const [metadata, setMetadata] = createStore<PDFDocumentMetadata>({ ...EMPTY_METADATA });
   const [toasts, setToasts] = createSignal<Toast[]>([]);
 
   onMount(() => {
@@ -162,6 +173,18 @@ export default function Editor() {
 
   // --- File loading ---
 
+  async function syncMetadataFromFile(file: File): Promise<void> {
+    try {
+      const loadedMetadata = await pdfService.getMetadata(file);
+      setSourceMetadata(loadedMetadata);
+      setMetadata(loadedMetadata);
+    } catch (err) {
+      console.error("Failed to read PDF metadata:", err);
+      setSourceMetadata({ ...EMPTY_METADATA });
+      setMetadata({ ...EMPTY_METADATA });
+    }
+  }
+
   function handleFileLoaded(file: File, pageCount: number): void {
     setPages(createPageStates(file, pageCount));
     setSelectedIndices(new Set<number>());
@@ -192,6 +215,7 @@ export default function Editor() {
     const pageCount = await loadPdfFile(file, "upload");
     if (pageCount === null) return;
 
+    await syncMetadataFromFile(file);
     handleFileLoaded(file, pageCount);
   }
 
@@ -282,6 +306,36 @@ export default function Editor() {
     } catch (err) {
       console.error("Failed to build PDF:", err);
       dispatchToast("Failed to build the PDF.", "error");
+    } finally {
+      setReadyStatus();
+    }
+  }
+
+  async function handleMetadataDownload(): Promise<void> {
+    if (isBusy()) return;
+
+    const totalPages = activePageCount();
+    setOperation("building");
+    setStatusMessage(`Applying metadata... 0/${totalPages}`);
+
+    try {
+      const result = await pdfOperationsService.buildPDFWithMetadata(
+        pages,
+        {
+          title: metadata.title.trim() || sourceMetadata.title,
+          author: metadata.author.trim() || sourceMetadata.author,
+          subject: metadata.subject.trim() || sourceMetadata.subject,
+          keywords: metadata.keywords.trim() || sourceMetadata.keywords,
+        },
+        ({ completed, total }) => {
+          setStatusMessage(`Applying metadata... ${completed}/${total}`);
+        }
+      );
+      downloadPDF(result);
+      dispatchToast("Metadata download started.", "success");
+    } catch (err) {
+      console.error("Failed to apply metadata:", err);
+      dispatchToast("Failed to apply metadata.", "error");
     } finally {
       setReadyStatus();
     }
@@ -423,6 +477,9 @@ export default function Editor() {
             <EditorSidebar
               busy={isBusy()}
               selectedCount={selectedIndices().size}
+              metadata={metadata}
+              onMetadataChange={(field, value) => setMetadata(field, value)}
+              onMetadataDownload={handleMetadataDownload}
               onSelectAll={handleSelectAll}
               onRotate={handleRotateSelected}
               onDelete={handleDeleteSelected}

--- a/src/components/app/EditorSidebar.tsx
+++ b/src/components/app/EditorSidebar.tsx
@@ -1,6 +1,14 @@
 interface Props {
   busy: boolean;
   selectedCount: number;
+  metadata: {
+    title: string;
+    author: string;
+    subject: string;
+    keywords: string;
+  };
+  onMetadataChange: (field: "title" | "author" | "subject" | "keywords", value: string) => void;
+  onMetadataDownload: () => void;
   onSelectAll: () => void;
   onRotate: () => void;
   onDelete: () => void;
@@ -92,16 +100,67 @@ export default function EditorSidebar(props: Props) {
       </div>
 
       {/* Export — pinned to bottom */}
-      <div class="p-4 border-t border-[#ddd] flex-shrink-0">
-        <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
-        <button
-          data-testid="editor-download-button"
-          onClick={props.onDownload}
-          disabled={props.busy}
-          class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {props.busy ? "Working..." : "Download"}
-        </button>
+      <div class="p-4 border-t border-[#ddd] flex-shrink-0 space-y-4">
+        <div>
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Metadata</p>
+          <div class="space-y-2">
+            <input
+              data-testid="editor-metadata-title"
+              type="text"
+              placeholder="Title"
+              value={props.metadata.title}
+              disabled={props.busy}
+              onInput={(e) => props.onMetadataChange("title", e.currentTarget.value)}
+              class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <input
+              data-testid="editor-metadata-author"
+              type="text"
+              placeholder="Author"
+              value={props.metadata.author}
+              disabled={props.busy}
+              onInput={(e) => props.onMetadataChange("author", e.currentTarget.value)}
+              class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <input
+              data-testid="editor-metadata-subject"
+              type="text"
+              placeholder="Subject"
+              value={props.metadata.subject}
+              disabled={props.busy}
+              onInput={(e) => props.onMetadataChange("subject", e.currentTarget.value)}
+              class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <input
+              data-testid="editor-metadata-keywords"
+              type="text"
+              placeholder="Keywords"
+              value={props.metadata.keywords}
+              disabled={props.busy}
+              onInput={(e) => props.onMetadataChange("keywords", e.currentTarget.value)}
+              class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+          </div>
+          <button
+            data-testid="editor-metadata-button"
+            onClick={props.onMetadataDownload}
+            disabled={props.busy}
+            class="mt-3 w-full border border-[#111] bg-transparent py-3 text-[11px] font-semibold uppercase tracking-[0.15em] text-[#111] transition-colors hover:bg-[#111] hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Apply Metadata & Download
+          </button>
+        </div>
+        <div>
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
+          <button
+            data-testid="editor-download-button"
+            onClick={props.onDownload}
+            disabled={props.busy}
+            class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {props.busy ? "Working..." : "Download"}
+          </button>
+        </div>
       </div>
     </aside>
   );

--- a/src/services/__tests__/pdf-operations-service.test.ts
+++ b/src/services/__tests__/pdf-operations-service.test.ts
@@ -10,10 +10,16 @@ const createMockPage = (overrides: Partial<PageState> = {}): PageState => ({
   ...overrides,
 });
 
+const mockCopiedPage = { setRotation: vi.fn() };
+
 const mockPDFDoc = {
-  copyPages: vi.fn().mockResolvedValue([{ setRotation: vi.fn() }]),
+  copyPages: vi.fn().mockResolvedValue([mockCopiedPage]),
   addPage: vi.fn(),
   save: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
+  setTitle: vi.fn(),
+  setAuthor: vi.fn(),
+  setSubject: vi.fn(),
+  setKeywords: vi.fn(),
   getPageCount: vi.fn().mockReturnValue(1),
 };
 
@@ -158,6 +164,41 @@ describe("PDFOperationsService", () => {
       await expect(service.buildPDFFromSubset(pages, [])).rejects.toThrow(
         "No pages selected for extraction"
       );
+    });
+  });
+
+  describe("buildPDFWithMetadata", () => {
+    it("applies provided metadata to the built PDF", async () => {
+      const service = new PDFOperationsService();
+
+      const result = await service.buildPDFWithMetadata([createMockPage()], {
+        title: "My Title",
+        author: "Jane Smith",
+        subject: "Quarterly Report",
+        keywords: "finance, quarterly",
+      });
+
+      expect(mockPDFDoc.setTitle).toHaveBeenCalledWith("My Title");
+      expect(mockPDFDoc.setAuthor).toHaveBeenCalledWith("Jane Smith");
+      expect(mockPDFDoc.setSubject).toHaveBeenCalledWith("Quarterly Report");
+      expect(mockPDFDoc.setKeywords).toHaveBeenCalledWith(["finance", "quarterly"]);
+      expect(result.suggestedFileName).toBe("quire-output.pdf");
+    });
+
+    it("skips blank metadata fields", async () => {
+      const service = new PDFOperationsService();
+
+      await service.buildPDFWithMetadata([createMockPage()], {
+        title: "  ",
+        author: "",
+        subject: "",
+        keywords: "  ",
+      });
+
+      expect(mockPDFDoc.setTitle).not.toHaveBeenCalled();
+      expect(mockPDFDoc.setAuthor).not.toHaveBeenCalled();
+      expect(mockPDFDoc.setSubject).not.toHaveBeenCalled();
+      expect(mockPDFDoc.setKeywords).not.toHaveBeenCalled();
     });
   });
 

--- a/src/services/__tests__/pdf-service.test.ts
+++ b/src/services/__tests__/pdf-service.test.ts
@@ -22,6 +22,10 @@ const pdfLibLoadMock = vi.fn().mockImplementation(async (buffer: ArrayBuffer, op
 
   return {
     getPageCount: vi.fn().mockReturnValue(label.includes("two-pages") ? 2 : 5),
+    getTitle: vi.fn().mockReturnValue(label.includes("metadata") ? "Source Title" : undefined),
+    getAuthor: vi.fn().mockReturnValue(label.includes("metadata") ? "Source Author" : undefined),
+    getSubject: vi.fn().mockReturnValue(label.includes("metadata") ? "Source Subject" : undefined),
+    getKeywords: vi.fn().mockReturnValue(label.includes("metadata") ? "one, two" : undefined),
   };
 });
 
@@ -198,6 +202,20 @@ describe("PDFService", () => {
     await service.renderPage(file, 1, canvas, 1, 90);
 
     expect(canvas.width).toBeGreaterThan(canvas.height);
+  });
+
+  it("returns metadata for the requested file", async () => {
+    const service = new PDFService();
+    const file = new File(["metadata"], "metadata.pdf", { type: "application/pdf" });
+
+    await service.loadPDF(file);
+
+    await expect(service.getMetadata(file)).resolves.toEqual({
+      title: "Source Title",
+      author: "Source Author",
+      subject: "Source Subject",
+      keywords: "one, two",
+    });
   });
 
   it("returns page info for the requested file", async () => {

--- a/src/services/pdf-operations-service.ts
+++ b/src/services/pdf-operations-service.ts
@@ -5,6 +5,7 @@ import type {
   PDFOperationResult,
   IPDFOperationsService,
   PDFBuildProgress,
+  PDFDocumentMetadata,
 } from "../types/interfaces";
 
 export class PDFOperationsService implements IPDFOperationsService {
@@ -69,11 +70,37 @@ export class PDFOperationsService implements IPDFOperationsService {
     );
   }
 
+  /**
+   * Builds a new PDF and applies document metadata to the output.
+   *
+   * @param pages - The current editor page state to export.
+   * @param metadata - The metadata values to apply to the output document.
+   * @param onProgress - Optional callback invoked after each page is copied.
+   * @returns The generated PDF bytes and a suggested download filename.
+   * @throws {Error} When there are no active pages to include in the output.
+   */
+  async buildPDFWithMetadata(
+    pages: PageState[],
+    metadata: PDFDocumentMetadata,
+    onProgress?: (progress: PDFBuildProgress) => void
+  ): Promise<PDFOperationResult> {
+    const activePages = pages.filter((page) => !page.markedForDeletion);
+
+    return this.buildOutputFromPages(
+      activePages,
+      "No pages to include in the PDF",
+      OUTPUT_FILENAME,
+      onProgress,
+      metadata
+    );
+  }
+
   private async buildOutputFromPages(
     pagesToBuild: PageState[],
     emptyStateMessage: string,
     suggestedFileName: string,
-    onProgress?: (progress: PDFBuildProgress) => void
+    onProgress?: (progress: PDFBuildProgress) => void,
+    metadata?: PDFDocumentMetadata
   ): Promise<PDFOperationResult> {
     if (pagesToBuild.length === 0) {
       throw new Error(emptyStateMessage);
@@ -91,6 +118,26 @@ export class PDFOperationsService implements IPDFOperationsService {
 
       outputDoc.addPage(copiedPage);
       onProgress?.({ completed: index + 1, total: pagesToBuild.length });
+    }
+
+    if (metadata) {
+      if (metadata.title.trim()) {
+        outputDoc.setTitle(metadata.title.trim());
+      }
+      if (metadata.author.trim()) {
+        outputDoc.setAuthor(metadata.author.trim());
+      }
+      if (metadata.subject.trim()) {
+        outputDoc.setSubject(metadata.subject.trim());
+      }
+      if (metadata.keywords.trim()) {
+        outputDoc.setKeywords(
+          metadata.keywords
+            .split(",")
+            .map((keyword) => keyword.trim())
+            .filter(Boolean)
+        );
+      }
     }
 
     const data = await outputDoc.save();

--- a/src/services/pdf-service.ts
+++ b/src/services/pdf-service.ts
@@ -1,7 +1,7 @@
 import { PDFDocument } from "pdf-lib";
 import * as pdfjsLib from "pdfjs-dist";
 import pdfjsWorker from "pdfjs-dist/build/pdf.worker.min.mjs?url";
-import type { PDFPageInfo, IPDFService } from "../types/interfaces";
+import type { PDFDocumentMetadata, PDFPageInfo, IPDFService } from "../types/interfaces";
 import { PDFPasswordRequiredError } from "../types/interfaces";
 
 // Configure PDF.js worker
@@ -127,6 +127,24 @@ export class PDFService implements IPDFService {
       viewport,
       canvas,
     }).promise;
+  }
+
+  /**
+   * Returns metadata for the requested PDF file.
+   *
+   * @param file - The source PDF file to inspect.
+   * @returns The title, author, subject, and keywords currently stored in the document.
+   * @throws {PDFPasswordRequiredError} When the source PDF requires a password.
+   */
+  async getMetadata(file: File): Promise<PDFDocumentMetadata> {
+    const record = await this.getOrLoadDocument(file);
+
+    return {
+      title: record.pdfDocument.getTitle() ?? "",
+      author: record.pdfDocument.getAuthor() ?? "",
+      subject: record.pdfDocument.getSubject() ?? "",
+      keywords: record.pdfDocument.getKeywords() ?? "",
+    };
   }
 
   /**

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -18,6 +18,13 @@ export interface PDFPageInfo {
   height: number;
 }
 
+export interface PDFDocumentMetadata {
+  title: string;
+  author: string;
+  subject: string;
+  keywords: string;
+}
+
 export interface PageState {
   id: string;
   sourceFile: File;
@@ -62,6 +69,21 @@ export interface IPDFOperationsService {
   buildPDFFromSubset(
     pages: PageState[],
     indices: number[],
+    onProgress?: (progress: PDFBuildProgress) => void
+  ): Promise<PDFOperationResult>;
+
+  /**
+   * Builds a new PDF and applies document metadata to the output.
+   *
+   * @param pages - The current editor page state to export.
+   * @param metadata - The metadata values to apply to the output document.
+   * @param onProgress - Optional callback invoked after each page is copied.
+   * @returns The generated PDF bytes and a suggested download filename.
+   * @throws {Error} When there are no active pages to include in the output.
+   */
+  buildPDFWithMetadata(
+    pages: PageState[],
+    metadata: PDFDocumentMetadata,
     onProgress?: (progress: PDFBuildProgress) => void
   ): Promise<PDFOperationResult>;
 
@@ -161,6 +183,15 @@ export interface IPDFService extends IPDFLoader, IPDFRenderer {
    * @throws {PDFPasswordRequiredError} When the password is missing or incorrect.
    */
   loadPDFWithPassword(file: File, password: string): Promise<void>;
+
+  /**
+   * Returns metadata for the requested PDF file.
+   *
+   * @param file - The PDF file whose metadata should be read.
+   * @returns The title, author, subject, and keywords currently stored in the document.
+   * @throws {PDFPasswordRequiredError} When the source PDF requires a password.
+   */
+  getMetadata(file: File): Promise<PDFDocumentMetadata>;
 
   /**
    * Returns the cached password previously used for a file in this session.

--- a/tests/e2e/core-app.spec.ts
+++ b/tests/e2e/core-app.spec.ts
@@ -65,6 +65,22 @@ test("adds another PDF to the current session", async ({ page }) => {
   await expect(page.getByTestId("editor-toast").last()).toContainText("Added 2 pages");
 });
 
+test("downloads a PDF with updated metadata", async ({ page }) => {
+  await page.goto("/app");
+  await uploadPdf(page, samplePdf);
+  await waitForEditorReady(page);
+
+  await page.getByTestId("editor-metadata-title").fill("Quarterly Report");
+  await page.getByTestId("editor-metadata-author").fill("Jane Smith");
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByTestId("editor-metadata-button").click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toBe("quire-output.pdf");
+  await expect(page.getByTestId("editor-toast").last()).toContainText("Metadata download started.");
+});
+
 test("prompts for encrypted PDFs and accepts the correct password", async ({ page }) => {
   await page.goto("/app");
   await uploadPdf(page, encryptedPdf);


### PR DESCRIPTION
## Summary
Add an editor metadata panel so users can review source metadata, update the fields, and download a PDF with the desired document properties applied.

## Changes
- add PDF metadata reads to the PDF service and metadata-aware PDF export support to the operations service with unit coverage
- add a metadata panel in the editor sidebar, prefill it from the loaded source document, and cover the download action in Playwright

## Testing
- [x] bun run verify
- [ ] Manually validate metadata field prefills and downloaded PDF properties in a desktop PDF viewer

## References
- Ticket/Issue: Fixes #55