### PR TITLE
feat: add page number downloads

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -49,6 +49,12 @@ export default function Editor() {
   const [dragOverTarget, setDragOverTarget] = createSignal<DragOverTarget | null>(null);
   const [operation, setOperation] = createSignal<EditorOperation>("idle");
   const [statusMessage, setStatusMessage] = createSignal("Drop a PDF to begin");
+  const [pageNumberOptions, setPageNumberOptions] = createStore({
+    position: "bottom-center" as const,
+    startNumber: 1,
+    format: "number" as const,
+    fontSize: 16,
+  });
   const [toasts, setToasts] = createSignal<Toast[]>([]);
 
   onMount(() => {
@@ -287,6 +293,24 @@ export default function Editor() {
     }
   }
 
+  async function handlePageNumbersDownload(): Promise<void> {
+    if (isBusy()) return;
+
+    setOperation("building");
+    setStatusMessage("Applying page numbers...");
+
+    try {
+      const result = await pdfOperationsService.addPageNumbers(pages, pageNumberOptions);
+      downloadPDF(result);
+      dispatchToast("Page-numbered PDF download started.", "success");
+    } catch (err) {
+      console.error("Failed to apply page numbers:", err);
+      dispatchToast("Failed to apply page numbers.", "error");
+    } finally {
+      setReadyStatus();
+    }
+  }
+
   // --- Drag and drop ---
 
   function handleDragStart(index: number, e: DragEvent): void {
@@ -423,6 +447,17 @@ export default function Editor() {
             <EditorSidebar
               busy={isBusy()}
               selectedCount={selectedIndices().size}
+              pageNumberOptions={pageNumberOptions}
+              onPageNumberOptionChange={(field, value) => {
+                if (field === "startNumber" || field === "fontSize") {
+                  const parsed = Number.parseInt(value, 10);
+                  setPageNumberOptions(field, Number.isNaN(parsed) ? 1 : parsed);
+                  return;
+                }
+
+                setPageNumberOptions(field, value as (typeof pageNumberOptions)[typeof field]);
+              }}
+              onPageNumberDownload={handlePageNumbersDownload}
               onSelectAll={handleSelectAll}
               onRotate={handleRotateSelected}
               onDelete={handleDeleteSelected}

--- a/src/components/app/EditorSidebar.tsx
+++ b/src/components/app/EditorSidebar.tsx
@@ -1,6 +1,17 @@
 interface Props {
   busy: boolean;
   selectedCount: number;
+  pageNumberOptions: {
+    position: "bottom-center" | "bottom-right" | "bottom-left" | "top-right";
+    startNumber: number;
+    format: "number" | "page-number" | "number-of-total";
+    fontSize: number;
+  };
+  onPageNumberOptionChange: (
+    field: "position" | "startNumber" | "format" | "fontSize",
+    value: string
+  ) => void;
+  onPageNumberDownload: () => void;
   onSelectAll: () => void;
   onRotate: () => void;
   onDelete: () => void;
@@ -92,16 +103,72 @@ export default function EditorSidebar(props: Props) {
       </div>
 
       {/* Export — pinned to bottom */}
-      <div class="p-4 border-t border-[#ddd] flex-shrink-0">
-        <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
-        <button
-          data-testid="editor-download-button"
-          onClick={props.onDownload}
-          disabled={props.busy}
-          class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {props.busy ? "Working..." : "Download"}
-        </button>
+      <div class="p-4 border-t border-[#ddd] flex-shrink-0 space-y-4">
+        <div>
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Page Numbers</p>
+          <div class="space-y-2">
+            <select
+              data-testid="editor-page-numbers-position"
+              value={props.pageNumberOptions.position}
+              disabled={props.busy}
+              onChange={(e) => props.onPageNumberOptionChange("position", e.currentTarget.value)}
+              class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <option value="bottom-center">Bottom center</option>
+              <option value="bottom-right">Bottom right</option>
+              <option value="bottom-left">Bottom left</option>
+              <option value="top-right">Top right</option>
+            </select>
+            <input
+              data-testid="editor-page-numbers-start"
+              type="number"
+              min="1"
+              value={props.pageNumberOptions.startNumber}
+              disabled={props.busy}
+              onInput={(e) => props.onPageNumberOptionChange("startNumber", e.currentTarget.value)}
+              class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <select
+              data-testid="editor-page-numbers-format"
+              value={props.pageNumberOptions.format}
+              disabled={props.busy}
+              onChange={(e) => props.onPageNumberOptionChange("format", e.currentTarget.value)}
+              class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              <option value="number">1</option>
+              <option value="page-number">Page 1</option>
+              <option value="number-of-total">1 / N</option>
+            </select>
+            <input
+              data-testid="editor-page-numbers-font-size"
+              type="number"
+              min="8"
+              value={props.pageNumberOptions.fontSize}
+              disabled={props.busy}
+              onInput={(e) => props.onPageNumberOptionChange("fontSize", e.currentTarget.value)}
+              class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+            />
+          </div>
+          <button
+            data-testid="editor-page-numbers-button"
+            onClick={props.onPageNumberDownload}
+            disabled={props.busy}
+            class="mt-3 w-full border border-[#111] bg-transparent py-3 text-[11px] font-semibold uppercase tracking-[0.15em] text-[#111] transition-colors hover:bg-[#111] hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Apply Page Numbers & Download
+          </button>
+        </div>
+        <div>
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
+          <button
+            data-testid="editor-download-button"
+            onClick={props.onDownload}
+            disabled={props.busy}
+            class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {props.busy ? "Working..." : "Download"}
+          </button>
+        </div>
       </div>
     </aside>
   );

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,5 +19,8 @@ export const OUTPUT_FILENAME = "quire-output.pdf";
 /** Default file name when extracting a page subset */
 export const EXTRACT_FILENAME = "quire-extract.pdf";
 
+/** Default file name when downloading a PDF with page numbers applied */
+export const PAGE_NUMBERS_FILENAME = "quire-numbered.pdf";
+
 /** Title shown in the password prompt modal for encrypted PDFs */
 export const PASSWORD_MODAL_TITLE = "PASSWORD REQUIRED";

--- a/src/services/__tests__/pdf-operations-service.test.ts
+++ b/src/services/__tests__/pdf-operations-service.test.ts
@@ -10,9 +10,16 @@ const createMockPage = (overrides: Partial<PageState> = {}): PageState => ({
   ...overrides,
 });
 
+const mockCopiedPage = {
+  setRotation: vi.fn(),
+  getSize: vi.fn().mockReturnValue({ width: 600, height: 800 }),
+  drawText: vi.fn(),
+};
+
 const mockPDFDoc = {
-  copyPages: vi.fn().mockResolvedValue([{ setRotation: vi.fn() }]),
+  copyPages: vi.fn().mockResolvedValue([mockCopiedPage]),
   addPage: vi.fn(),
+  embedFont: vi.fn().mockResolvedValue({ widthOfTextAtSize: vi.fn().mockReturnValue(48) }),
   save: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
   getPageCount: vi.fn().mockReturnValue(1),
 };
@@ -27,6 +34,7 @@ vi.mock("pdf-lib", () => ({
     load: mockPDFDocument.load,
     create: mockPDFDocument.create,
   },
+  StandardFonts: { Helvetica: "Helvetica" },
   degrees: vi.fn((deg) => deg),
 }));
 
@@ -158,6 +166,42 @@ describe("PDFOperationsService", () => {
       await expect(service.buildPDFFromSubset(pages, [])).rejects.toThrow(
         "No pages selected for extraction"
       );
+    });
+  });
+
+  describe("addPageNumbers", () => {
+    it("adds page numbers using the provided format and position", async () => {
+      const service = new PDFOperationsService();
+
+      const result = await service.addPageNumbers(
+        [createMockPage(), createMockPage({ id: "page-2", sourcePageNumber: 2 })],
+        {
+          position: "bottom-right",
+          startNumber: 3,
+          format: "number-of-total",
+          fontSize: 18,
+        }
+      );
+
+      expect(mockPDFDoc.embedFont).toHaveBeenCalledWith("Helvetica");
+      expect(mockCopiedPage.drawText).toHaveBeenCalledWith(
+        "3 / 2",
+        expect.objectContaining({ size: 18, x: 528, y: 24 })
+      );
+      expect(result.suggestedFileName).toBe("quire-numbered.pdf");
+    });
+
+    it("rejects empty exports", async () => {
+      const service = new PDFOperationsService();
+
+      await expect(
+        service.addPageNumbers([], {
+          position: "bottom-center",
+          startNumber: 1,
+          format: "number",
+          fontSize: 16,
+        })
+      ).rejects.toThrow("No pages to include in the PDF");
     });
   });
 

--- a/src/services/pdf-operations-service.ts
+++ b/src/services/pdf-operations-service.ts
@@ -1,6 +1,7 @@
-import { PDFDocument, degrees } from "pdf-lib";
-import { EXTRACT_FILENAME, OUTPUT_FILENAME } from "../constants";
+import { PDFDocument, StandardFonts, degrees } from "pdf-lib";
+import { EXTRACT_FILENAME, OUTPUT_FILENAME, PAGE_NUMBERS_FILENAME } from "../constants";
 import type {
+  PageNumberOptions,
   PageState,
   PDFOperationResult,
   IPDFOperationsService,
@@ -69,6 +70,66 @@ export class PDFOperationsService implements IPDFOperationsService {
     );
   }
 
+  /**
+   * Builds a new PDF with page numbers applied to each active page.
+   *
+   * @param pages - The current editor page state to export.
+   * @param options - The page-number placement and formatting options.
+   * @returns The generated PDF bytes and a suggested download filename.
+   * @throws {Error} When there are no active pages to include in the output.
+   */
+  async addPageNumbers(
+    pages: PageState[],
+    options: PageNumberOptions
+  ): Promise<PDFOperationResult> {
+    const activePages = pages.filter((page) => !page.markedForDeletion);
+
+    if (activePages.length === 0) {
+      throw new Error("No pages to include in the PDF");
+    }
+
+    const outputDoc = await PDFDocument.create();
+    const font = await outputDoc.embedFont(StandardFonts.Helvetica);
+
+    for (const [index, page] of activePages.entries()) {
+      const sourceDoc = await this.getOrLoadSourceDoc(page.sourceFile);
+      const [copiedPage] = await outputDoc.copyPages(sourceDoc, [page.sourcePageNumber - 1]);
+
+      if (page.rotation !== 0) {
+        copiedPage.setRotation(degrees(page.rotation));
+      }
+
+      const number = options.startNumber + index;
+      const text = this.formatPageNumber(number, activePages.length, options.format);
+      const { width, height } = copiedPage.getSize();
+      const textWidth = font.widthOfTextAtSize(text, options.fontSize);
+      const margin = 24;
+      const x =
+        options.position === "bottom-center"
+          ? (width - textWidth) / 2
+          : options.position === "bottom-left"
+            ? margin
+            : width - textWidth - margin;
+      const y = options.position === "top-right" ? height - options.fontSize - margin : margin;
+
+      copiedPage.drawText(text, {
+        x,
+        y,
+        size: options.fontSize,
+        font,
+      });
+
+      outputDoc.addPage(copiedPage);
+    }
+
+    const data = await outputDoc.save();
+
+    return {
+      data: new Uint8Array(data),
+      suggestedFileName: PAGE_NUMBERS_FILENAME,
+    };
+  }
+
   private async buildOutputFromPages(
     pagesToBuild: PageState[],
     emptyStateMessage: string,
@@ -99,6 +160,21 @@ export class PDFOperationsService implements IPDFOperationsService {
       data: new Uint8Array(data),
       suggestedFileName,
     };
+  }
+
+  private formatPageNumber(
+    number: number,
+    totalPages: number,
+    format: PageNumberOptions["format"]
+  ): string {
+    switch (format) {
+      case "page-number":
+        return `Page ${number}`;
+      case "number-of-total":
+        return `${number} / ${totalPages}`;
+      default:
+        return `${number}`;
+    }
   }
 
   private async getOrLoadSourceDoc(file: File): Promise<PDFDocument> {

--- a/src/types/interfaces.ts
+++ b/src/types/interfaces.ts
@@ -36,6 +36,17 @@ export interface PDFBuildProgress {
   total: number;
 }
 
+export type PageNumberPosition = "bottom-center" | "bottom-right" | "bottom-left" | "top-right";
+
+export type PageNumberFormat = "number" | "page-number" | "number-of-total";
+
+export interface PageNumberOptions {
+  position: PageNumberPosition;
+  startNumber: number;
+  format: PageNumberFormat;
+  fontSize: number;
+}
+
 export interface IPDFOperationsService {
   /**
    * Builds a new PDF from every page that is not marked for deletion.
@@ -64,6 +75,16 @@ export interface IPDFOperationsService {
     indices: number[],
     onProgress?: (progress: PDFBuildProgress) => void
   ): Promise<PDFOperationResult>;
+
+  /**
+   * Builds a new PDF with page numbers applied to each active page.
+   *
+   * @param pages - The current editor page state to export.
+   * @param options - The page-number placement and formatting options.
+   * @returns The generated PDF bytes and a suggested download filename.
+   * @throws {Error} When there are no active pages to include in the output.
+   */
+  addPageNumbers(pages: PageState[], options: PageNumberOptions): Promise<PDFOperationResult>;
 
   /**
    * Clears any cached source documents held for the current editor session.

--- a/tests/e2e/core-app.spec.ts
+++ b/tests/e2e/core-app.spec.ts
@@ -65,6 +65,26 @@ test("adds another PDF to the current session", async ({ page }) => {
   await expect(page.getByTestId("editor-toast").last()).toContainText("Added 2 pages");
 });
 
+test("downloads a PDF with page numbers", async ({ page }) => {
+  await page.goto("/app");
+  await uploadPdf(page, samplePdf);
+  await waitForEditorReady(page);
+
+  await page.getByTestId("editor-page-numbers-position").selectOption("bottom-right");
+  await page.getByTestId("editor-page-numbers-start").fill("3");
+  await page.getByTestId("editor-page-numbers-format").selectOption("number-of-total");
+  await page.getByTestId("editor-page-numbers-font-size").fill("18");
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByTestId("editor-page-numbers-button").click();
+  const download = await downloadPromise;
+
+  expect(download.suggestedFilename()).toBe("quire-numbered.pdf");
+  await expect(page.getByTestId("editor-toast").last()).toContainText(
+    "Page-numbered PDF download started."
+  );
+});
+
 test("prompts for encrypted PDFs and accepts the correct password", async ({ page }) => {
   await page.goto("/app");
   await uploadPdf(page, encryptedPdf);


### PR DESCRIPTION
## Summary
Add a page-number export panel so users can number the final PDF with configurable position, starting value, format, and font size.

## Changes
- add a page-numbering operation in the PDF operations service with unit coverage for formatting and placement options
- expose page-number controls in the editor sidebar and cover the download action in Playwright

## Testing
- [x] bun run verify
- [ ] Manually validate page-number placement and sizing across different PDF shapes in the browser

## References
- Ticket/Issue: Fixes #53