### PR TITLE
feat: insert blank pages into PDF

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -195,6 +195,35 @@ export default function Editor() {
     handleFileLoaded(file, pageCount);
   }
 
+  // --- Blank pages ---
+
+  async function handleInsertBlank(): Promise<void> {
+    if (isBusy()) return;
+
+    try {
+      const blankFile = await pdfOperationsService.createBlankPageFile();
+      const createdAt = Date.now();
+      const blankPage: PageState = {
+        id: `blank-${createdAt}`,
+        sourceFile: blankFile,
+        sourcePageNumber: 1,
+        rotation: 0,
+        markedForDeletion: false,
+      };
+
+      setPages(
+        produce((draftPages) => {
+          draftPages.push(blankPage);
+        })
+      );
+      setStatusMessage("Blank page inserted.");
+      dispatchToast("Blank page added.", "success");
+    } catch (err) {
+      console.error("Failed to create blank page:", err);
+      dispatchToast("Failed to create blank page.", "error");
+    }
+  }
+
   // --- Selection ---
 
   function handlePageClick(index: number): void {
@@ -424,6 +453,7 @@ export default function Editor() {
               busy={isBusy()}
               selectedCount={selectedIndices().size}
               onSelectAll={handleSelectAll}
+              onInsertBlank={handleInsertBlank}
               onRotate={handleRotateSelected}
               onDelete={handleDeleteSelected}
               onExtract={handleExtract}

--- a/src/components/app/EditorPageTile.tsx
+++ b/src/components/app/EditorPageTile.tsx
@@ -58,7 +58,9 @@ export default function EditorPageTile(props: Props) {
         aria-label={
           props.page.markedForDeletion
             ? `Page ${props.index + 1}, marked for deletion`
-            : `Page ${props.index + 1}`
+            : props.page.sourceFile.name === "blank.pdf"
+              ? `Page ${props.index + 1}, blank`
+              : `Page ${props.index + 1}`
         }
         disabled={props.busy}
         onClick={props.onClick}
@@ -70,7 +72,9 @@ export default function EditorPageTile(props: Props) {
         />
       </button>
       <div class="page-controls">
-        <span class="page-label">Page {props.index + 1}</span>
+        <span class="page-label">
+          {props.page.sourceFile.name === "blank.pdf" ? "BLANK" : `Page ${props.index + 1}`}
+        </span>
         <button
           type="button"
           data-testid="editor-page-rotate-button"

--- a/src/components/app/EditorSidebar.tsx
+++ b/src/components/app/EditorSidebar.tsx
@@ -2,6 +2,7 @@ interface Props {
   busy: boolean;
   selectedCount: number;
   onSelectAll: () => void;
+  onInsertBlank: () => void;
   onRotate: () => void;
   onDelete: () => void;
   onExtract: () => void;
@@ -61,6 +62,15 @@ export default function EditorSidebar(props: Props) {
         {/* Actions */}
         <div class="p-4 border-b border-[#ddd]">
           <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Actions</p>
+          <button
+            data-testid="editor-insert-blank-button"
+            onClick={props.onInsertBlank}
+            aria-label="Insert a blank page after the last page"
+            disabled={props.busy}
+            class="w-full text-left text-xs text-[#555] hover:text-[#111] hover:bg-[#f5f5f5] bg-transparent border-none cursor-pointer py-2 px-2 transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Insert Blank Page
+          </button>
           <button
             data-testid="editor-rotate-button"
             onClick={props.onRotate}

--- a/src/services/__tests__/pdf-operations-service.test.ts
+++ b/src/services/__tests__/pdf-operations-service.test.ts
@@ -28,6 +28,9 @@ vi.mock("pdf-lib", () => ({
     create: mockPDFDocument.create,
   },
   degrees: vi.fn((deg) => deg),
+  PageSizes: {
+    Letter: [611.28, 792],
+  },
 }));
 
 describe("PDFOperationsService", () => {
@@ -158,6 +161,31 @@ describe("PDFOperationsService", () => {
       await expect(service.buildPDFFromSubset(pages, [])).rejects.toThrow(
         "No pages selected for extraction"
       );
+    });
+  });
+
+  describe("createBlankPageFile", () => {
+    it("should create a blank PDF file", async () => {
+      const service = new PDFOperationsService();
+      const file = await service.createBlankPageFile();
+
+      expect(file).toBeInstanceOf(File);
+      expect(file.name).toBe("blank.pdf");
+      expect(file.type).toBe("application/pdf");
+    });
+
+    it("should use default Letter dimensions", async () => {
+      const service = new PDFOperationsService();
+      await service.createBlankPageFile();
+
+      expect(mockPDFDoc.addPage).toHaveBeenCalledWith([611.28, 792]);
+    });
+
+    it("should accept custom dimensions", async () => {
+      const service = new PDFOperationsService();
+      await service.createBlankPageFile(500, 700);
+
+      expect(mockPDFDoc.addPage).toHaveBeenCalledWith([500, 700]);
     });
   });
 

--- a/src/services/pdf-operations-service.ts
+++ b/src/services/pdf-operations-service.ts
@@ -1,4 +1,4 @@
-import { PDFDocument, degrees } from "pdf-lib";
+import { PDFDocument, degrees, PageSizes } from "pdf-lib";
 import { EXTRACT_FILENAME, OUTPUT_FILENAME } from "../constants";
 import type {
   PageState,
@@ -99,6 +99,24 @@ export class PDFOperationsService implements IPDFOperationsService {
       data: new Uint8Array(data),
       suggestedFileName,
     };
+  }
+
+  /**
+   * Creates a single-page blank PDF file with the given dimensions.
+   *
+   * @param width - Page width in points (defaults to US Letter width).
+   * @param height - Page height in points (defaults to US Letter height).
+   * @returns A File containing a one-page blank PDF.
+   */
+  async createBlankPageFile(
+    width: number = PageSizes.Letter[0],
+    height: number = PageSizes.Letter[1]
+  ): Promise<File> {
+    const doc = await PDFDocument.create();
+    doc.addPage([width, height]);
+    const data = await doc.save();
+    const blob = new Blob([new Uint8Array(data)], { type: "application/pdf" });
+    return new File([blob], "blank.pdf", { type: "application/pdf" });
   }
 
   private async getOrLoadSourceDoc(file: File): Promise<PDFDocument> {

--- a/tests/e2e/core-app.spec.ts
+++ b/tests/e2e/core-app.spec.ts
@@ -65,6 +65,22 @@ test("adds another PDF to the current session", async ({ page }) => {
   await expect(page.getByTestId("editor-toast").last()).toContainText("Added 2 pages");
 });
 
+test("inserts a blank page and includes it in download", async ({ page }) => {
+  await page.goto("/app");
+  await uploadPdf(page, samplePdf);
+  await waitForEditorReady(page);
+  await expect(page.getByTestId("editor-page-tile")).toHaveCount(2);
+
+  await page.getByTestId("editor-insert-blank-button").click();
+  await expect(page.getByTestId("editor-page-tile")).toHaveCount(3);
+  await expect(page.getByTestId("editor-toast").last()).toContainText("Blank page added");
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByTestId("editor-download-button").click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("quire-output.pdf");
+});
+
 test("prompts for encrypted PDFs and accepts the correct password", async ({ page }) => {
   await page.goto("/app");
   await uploadPdf(page, encryptedPdf);


### PR DESCRIPTION
## Summary
Add the ability to insert blank pages into the PDF editor session.

## Changes
- Add `createBlankPageFile()` to `PDFOperationsService` — generates a single-page blank PDF using pdf-lib
- Add "Insert Blank Page" button in the sidebar Actions section
- Blank pages show a "BLANK" label in the tile instead of "Page N"
- Blank pages render as a real (empty) PDF page and are included in downloads
- Blank pages can be rotated, deleted, reordered, and extracted like any other page
- Unit tests for `createBlankPageFile` (default dimensions, custom dimensions)
- E2E test for insert + download flow

## Testing
- [x] `bun run verify` passes (type-check, lint, format, 42 unit tests, build)
- [ ] E2E on CI (Playwright)
- [ ] Manually verify blank page renders and downloads correctly

## References
- Closes #54