### PR TITLE
feat: password-protect output PDF

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -49,6 +49,7 @@ export default function Editor() {
   const [dragOverTarget, setDragOverTarget] = createSignal<DragOverTarget | null>(null);
   const [operation, setOperation] = createSignal<EditorOperation>("idle");
   const [statusMessage, setStatusMessage] = createSignal("Drop a PDF to begin");
+  const [protectPassword, setProtectPassword] = createSignal("");
   const [toasts, setToasts] = createSignal<Toast[]>([]);
 
   onMount(() => {
@@ -273,10 +274,18 @@ export default function Editor() {
     setOperation("building");
     setStatusMessage(`Building PDF... 0/${totalPages}`);
 
+    const password = protectPassword();
+    const passwordOptions =
+      password.length > 0 ? { userPassword: password, ownerPassword: password } : undefined;
+
     try {
-      const result = await pdfOperationsService.buildPDF(pages, ({ completed, total }) => {
-        setStatusMessage(`Building PDF... ${completed}/${total}`);
-      });
+      const result = await pdfOperationsService.buildPDF(
+        pages,
+        ({ completed, total }) => {
+          setStatusMessage(`Building PDF... ${completed}/${total}`);
+        },
+        passwordOptions
+      );
       downloadPDF(result);
       dispatchToast("Download started.", "success");
     } catch (err) {
@@ -423,6 +432,8 @@ export default function Editor() {
             <EditorSidebar
               busy={isBusy()}
               selectedCount={selectedIndices().size}
+              protectPassword={protectPassword()}
+              onProtectPasswordChange={setProtectPassword}
               onSelectAll={handleSelectAll}
               onRotate={handleRotateSelected}
               onDelete={handleDeleteSelected}

--- a/src/components/app/EditorSidebar.tsx
+++ b/src/components/app/EditorSidebar.tsx
@@ -1,6 +1,8 @@
 interface Props {
   busy: boolean;
   selectedCount: number;
+  protectPassword: string;
+  onProtectPasswordChange: (password: string) => void;
   onSelectAll: () => void;
   onRotate: () => void;
   onDelete: () => void;
@@ -93,6 +95,23 @@ export default function EditorSidebar(props: Props) {
 
       {/* Export — pinned to bottom */}
       <div class="p-4 border-t border-[#ddd] flex-shrink-0">
+        <div class="mb-3">
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-2">Password Protect</p>
+          <input
+            data-testid="editor-protect-password"
+            type="password"
+            placeholder="Optional password"
+            value={props.protectPassword}
+            disabled={props.busy}
+            onInput={(e) => props.onProtectPasswordChange(e.currentTarget.value)}
+            class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+          />
+          {props.protectPassword && (
+            <p class="text-[10px] text-[#ff0000] mt-1">
+              &#9888; This password cannot be recovered if forgotten.
+            </p>
+          )}
+        </div>
         <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
         <button
           data-testid="editor-download-button"

--- a/src/services/__tests__/pdf-operations-service.test.ts
+++ b/src/services/__tests__/pdf-operations-service.test.ts
@@ -110,6 +110,26 @@ describe("PDFOperationsService", () => {
       expect(onProgress).toHaveBeenNthCalledWith(1, { completed: 1, total: 2 });
       expect(onProgress).toHaveBeenNthCalledWith(2, { completed: 2, total: 2 });
     });
+
+    it("should pass password options to save when provided", async () => {
+      const service = new PDFOperationsService();
+      const passwordOptions = { userPassword: "secret", ownerPassword: "secret" };
+
+      await service.buildPDF([createMockPage()], undefined, passwordOptions);
+
+      expect(mockPDFDoc.save).toHaveBeenCalledWith({
+        userPassword: "secret",
+        ownerPassword: "secret",
+      });
+    });
+
+    it("should build without password when no options provided", async () => {
+      const service = new PDFOperationsService();
+
+      await service.buildPDF([createMockPage()]);
+
+      expect(mockPDFDoc.save).toHaveBeenCalledWith({});
+    });
   });
 
   describe("buildPDFFromSubset", () => {

--- a/src/services/pdf-operations-service.ts
+++ b/src/services/pdf-operations-service.ts
@@ -7,6 +7,11 @@ import type {
   PDFBuildProgress,
 } from "../types/interfaces";
 
+export interface PasswordProtectOptions {
+  userPassword: string;
+  ownerPassword: string;
+}
+
 export class PDFOperationsService implements IPDFOperationsService {
   // Class-level cache: avoids re-reading the same File on multiple build/extract
   // calls within one session. Cleared on session reset via clearCache().
@@ -31,7 +36,8 @@ export class PDFOperationsService implements IPDFOperationsService {
    */
   async buildPDF(
     pages: PageState[],
-    onProgress?: (progress: PDFBuildProgress) => void
+    onProgress?: (progress: PDFBuildProgress) => void,
+    passwordOptions?: PasswordProtectOptions
   ): Promise<PDFOperationResult> {
     const activePages = pages.filter((page) => !page.markedForDeletion);
 
@@ -39,7 +45,8 @@ export class PDFOperationsService implements IPDFOperationsService {
       activePages,
       "No pages to include in the PDF",
       OUTPUT_FILENAME,
-      onProgress
+      onProgress,
+      passwordOptions
     );
   }
 
@@ -73,7 +80,8 @@ export class PDFOperationsService implements IPDFOperationsService {
     pagesToBuild: PageState[],
     emptyStateMessage: string,
     suggestedFileName: string,
-    onProgress?: (progress: PDFBuildProgress) => void
+    onProgress?: (progress: PDFBuildProgress) => void,
+    passwordOptions?: PasswordProtectOptions
   ): Promise<PDFOperationResult> {
     if (pagesToBuild.length === 0) {
       throw new Error(emptyStateMessage);
@@ -93,7 +101,13 @@ export class PDFOperationsService implements IPDFOperationsService {
       onProgress?.({ completed: index + 1, total: pagesToBuild.length });
     }
 
-    const data = await outputDoc.save();
+    const saveOptions: Record<string, unknown> = {};
+    if (passwordOptions?.userPassword) {
+      saveOptions.userPassword = passwordOptions.userPassword;
+      saveOptions.ownerPassword = passwordOptions.ownerPassword || passwordOptions.userPassword;
+    }
+
+    const data = await outputDoc.save(saveOptions);
 
     return {
       data: new Uint8Array(data),

--- a/tests/e2e/core-app.spec.ts
+++ b/tests/e2e/core-app.spec.ts
@@ -65,6 +65,20 @@ test("adds another PDF to the current session", async ({ page }) => {
   await expect(page.getByTestId("editor-toast").last()).toContainText("Added 2 pages");
 });
 
+test("downloads a password-protected PDF", async ({ page }) => {
+  await page.goto("/app");
+  await uploadPdf(page, samplePdf);
+  await waitForEditorReady(page);
+
+  await page.getByTestId("editor-protect-password").fill("test-password");
+  await expect(page.getByText("cannot be recovered")).toBeVisible();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByTestId("editor-download-button").click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toBe("quire-output.pdf");
+});
+
 test("prompts for encrypted PDFs and accepts the correct password", async ({ page }) => {
   await page.goto("/app");
   await uploadPdf(page, encryptedPdf);


### PR DESCRIPTION
## Summary
Add optional password protection for the downloaded PDF using pdf-lib encryption-on-save.

## Changes
- Add `PasswordProtectOptions` interface to pdf-operations-service
- `buildPDF()` accepts optional password options, passes `userPassword`/`ownerPassword` to `pdfDoc.save()`
- Sidebar gains a "Password Protect" input above the Download button
- Warning about password recovery shown when password is entered
- Unit tests for password-protected and unprotected builds
- E2E test for password-protected download flow

## Testing
- [x] `bun run verify` passes (41 unit tests, type-check, lint, format, build)
- [ ] E2E on CI (Playwright)
- [ ] Manually verify encrypted PDF opens with password

## References
- Closes #56