### PR TITLE
feat: normalize page sizes when merging PDFs

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -4,7 +4,7 @@ import { ROTATION_STEP } from "../../constants";
 import type { PageState } from "../../types/interfaces";
 import { PDFPasswordRequiredError } from "../../types/interfaces";
 import { pdfService } from "../../services/pdf-service";
-import { pdfOperationsService } from "../../services/pdf-operations-service";
+import { pdfOperationsService, PDFOperationsService } from "../../services/pdf-operations-service";
 import {
   createPageStates,
   remapSelectionAfterMove,
@@ -49,6 +49,7 @@ export default function Editor() {
   const [dragOverTarget, setDragOverTarget] = createSignal<DragOverTarget | null>(null);
   const [operation, setOperation] = createSignal<EditorOperation>("idle");
   const [statusMessage, setStatusMessage] = createSignal("Drop a PDF to begin");
+  const [normalizeTarget, setNormalizeTarget] = createSignal("");
   const [toasts, setToasts] = createSignal<Toast[]>([]);
 
   onMount(() => {
@@ -287,6 +288,36 @@ export default function Editor() {
     }
   }
 
+  async function handleNormalizeDownload(): Promise<void> {
+    if (isBusy()) return;
+    const target = normalizeTarget();
+    if (!target) return;
+
+    const targetSize = PDFOperationsService.TARGET_SIZES[target];
+    if (!targetSize) return;
+
+    const totalPages = activePageCount();
+    setOperation("building");
+    setStatusMessage(`Normalizing to ${target}... 0/${totalPages}`);
+
+    try {
+      const result = await pdfOperationsService.buildNormalizedPDF(
+        pages,
+        targetSize,
+        ({ completed, total }) => {
+          setStatusMessage(`Normalizing... ${completed}/${total}`);
+        }
+      );
+      downloadPDF(result);
+      dispatchToast(`Normalized ${target} PDF download started.`, "success");
+    } catch (err) {
+      console.error("Failed to normalize PDF:", err);
+      dispatchToast("Failed to normalize the PDF.", "error");
+    } finally {
+      setReadyStatus();
+    }
+  }
+
   // --- Drag and drop ---
 
   function handleDragStart(index: number, e: DragEvent): void {
@@ -423,11 +454,14 @@ export default function Editor() {
             <EditorSidebar
               busy={isBusy()}
               selectedCount={selectedIndices().size}
+              normalizeTarget={normalizeTarget()}
+              onNormalizeTargetChange={setNormalizeTarget}
               onSelectAll={handleSelectAll}
               onRotate={handleRotateSelected}
               onDelete={handleDeleteSelected}
               onExtract={handleExtract}
               onDownload={handleDownload}
+              onNormalizeDownload={handleNormalizeDownload}
               onAddPdf={handleAddPdf}
             />
 

--- a/src/components/app/EditorSidebar.tsx
+++ b/src/components/app/EditorSidebar.tsx
@@ -1,11 +1,14 @@
 interface Props {
   busy: boolean;
   selectedCount: number;
+  normalizeTarget: string;
+  onNormalizeTargetChange: (target: string) => void;
   onSelectAll: () => void;
   onRotate: () => void;
   onDelete: () => void;
   onExtract: () => void;
   onDownload: () => void;
+  onNormalizeDownload: () => void;
   onAddPdf: (file: File) => void;
 }
 
@@ -92,16 +95,42 @@ export default function EditorSidebar(props: Props) {
       </div>
 
       {/* Export — pinned to bottom */}
-      <div class="p-4 border-t border-[#ddd] flex-shrink-0">
-        <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
-        <button
-          data-testid="editor-download-button"
-          onClick={props.onDownload}
-          disabled={props.busy}
-          class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {props.busy ? "Working..." : "Download"}
-        </button>
+      <div class="p-4 border-t border-[#ddd] flex-shrink-0 space-y-3">
+        <div>
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-2">Normalize</p>
+          <select
+            data-testid="editor-normalize-target"
+            value={props.normalizeTarget}
+            disabled={props.busy}
+            onChange={(e) => props.onNormalizeTargetChange(e.currentTarget.value)}
+            class="w-full border border-[#ddd] px-2 py-2 text-xs text-[#111] outline-none focus:border-[#111] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            <option value="">Off</option>
+            <option value="letter">US Letter</option>
+            <option value="a4">A4</option>
+          </select>
+        </div>
+        {props.normalizeTarget && (
+          <button
+            data-testid="editor-normalize-download-button"
+            onClick={props.onNormalizeDownload}
+            disabled={props.busy}
+            class="w-full border border-[#111] bg-transparent py-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-[#111] transition-colors hover:bg-[#111] hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Download Normalized
+          </button>
+        )}
+        <div>
+          <p class="text-[11px] uppercase tracking-wider text-[#888] mb-3">Export</p>
+          <button
+            data-testid="editor-download-button"
+            onClick={props.onDownload}
+            disabled={props.busy}
+            class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {props.busy ? "Working..." : "Download"}
+          </button>
+        </div>
       </div>
     </aside>
   );

--- a/src/services/__tests__/pdf-operations-service.test.ts
+++ b/src/services/__tests__/pdf-operations-service.test.ts
@@ -10,11 +10,22 @@ const createMockPage = (overrides: Partial<PageState> = {}): PageState => ({
   ...overrides,
 });
 
+const createMockPdfPage = () => ({
+  setRotation: vi.fn(),
+  getSize: vi.fn().mockReturnValue({ width: 612, height: 792 }),
+  setSize: vi.fn(),
+  scale: vi.fn(),
+  translateContent: vi.fn(),
+});
+
+const mockCopiedPage = createMockPdfPage();
+
 const mockPDFDoc = {
-  copyPages: vi.fn().mockResolvedValue([{ setRotation: vi.fn() }]),
+  copyPages: vi.fn().mockResolvedValue([mockCopiedPage]),
   addPage: vi.fn(),
   save: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
   getPageCount: vi.fn().mockReturnValue(1),
+  getPages: vi.fn().mockReturnValue([mockCopiedPage]),
 };
 
 const mockPDFDocument = {
@@ -28,6 +39,10 @@ vi.mock("pdf-lib", () => ({
     create: mockPDFDocument.create,
   },
   degrees: vi.fn((deg) => deg),
+  PageSizes: {
+    Letter: [611.28, 792],
+    A4: [595.28, 841.89],
+  },
 }));
 
 describe("PDFOperationsService", () => {
@@ -158,6 +173,36 @@ describe("PDFOperationsService", () => {
       await expect(service.buildPDFFromSubset(pages, [])).rejects.toThrow(
         "No pages selected for extraction"
       );
+    });
+  });
+
+  describe("buildNormalizedPDF", () => {
+    it("should create a normalized PDF", async () => {
+      const service = new PDFOperationsService();
+      const result = await service.buildNormalizedPDF([createMockPage()], [611.28, 792]);
+
+      expect(result.data).toBeInstanceOf(Uint8Array);
+      expect(result.suggestedFileName).toBe("quire-output.pdf");
+    });
+
+    it("should throw when no active pages", async () => {
+      const service = new PDFOperationsService();
+      const deleted = createMockPage({ markedForDeletion: true });
+
+      await expect(service.buildNormalizedPDF([deleted], [611.28, 792])).rejects.toThrow(
+        "No pages to include in the PDF"
+      );
+    });
+
+    it("should report progress", async () => {
+      const service = new PDFOperationsService();
+      const onProgress = vi.fn();
+      const pages = [createMockPage(), createMockPage({ id: "page-2", sourcePageNumber: 2 })];
+
+      await service.buildNormalizedPDF(pages, [611.28, 792], onProgress);
+
+      expect(onProgress).toHaveBeenNthCalledWith(1, { completed: 1, total: 2 });
+      expect(onProgress).toHaveBeenNthCalledWith(2, { completed: 2, total: 2 });
     });
   });
 

--- a/src/services/pdf-operations-service.ts
+++ b/src/services/pdf-operations-service.ts
@@ -1,4 +1,4 @@
-import { PDFDocument, degrees } from "pdf-lib";
+import { PDFDocument, PageSizes, degrees } from "pdf-lib";
 import { EXTRACT_FILENAME, OUTPUT_FILENAME } from "../constants";
 import type {
   PageState,
@@ -67,6 +67,77 @@ export class PDFOperationsService implements IPDFOperationsService {
       EXTRACT_FILENAME,
       onProgress
     );
+  }
+
+  /**
+   * Target page sizes for normalization.
+   */
+  static readonly TARGET_SIZES: Record<string, [number, number]> = {
+    letter: PageSizes.Letter,
+    a4: PageSizes.A4,
+  };
+
+  /**
+   * Builds a new PDF from every page that is not marked for deletion,
+   * with all pages scaled to fit a uniform target size.
+   *
+   * @param pages - The current editor page state to export.
+   * @param targetSize - The target dimensions as [width, height] in points.
+   * @param onProgress - Optional callback invoked after each page is copied.
+   * @returns The generated PDF bytes and a suggested download filename.
+   * @throws {Error} When there are no active pages to include in the output.
+   */
+  async buildNormalizedPDF(
+    pages: PageState[],
+    targetSize: [number, number],
+    onProgress?: (progress: PDFBuildProgress) => void
+  ): Promise<PDFOperationResult> {
+    const activePages = pages.filter((page) => !page.markedForDeletion);
+
+    if (activePages.length === 0) {
+      throw new Error("No pages to include in the PDF");
+    }
+
+    const outputDoc = await PDFDocument.create();
+
+    for (const [index, page] of activePages.entries()) {
+      const sourceDoc = await this.getOrLoadSourceDoc(page.sourceFile);
+      const [copiedPage] = await outputDoc.copyPages(sourceDoc, [page.sourcePageNumber - 1]);
+
+      if (page.rotation !== 0) {
+        copiedPage.setRotation(degrees(page.rotation));
+      }
+
+      outputDoc.addPage(copiedPage);
+      onProgress?.({ completed: index + 1, total: activePages.length });
+    }
+
+    // Normalize all pages to the target size
+    const targetWidth = targetSize[0];
+    const targetHeight = targetSize[1];
+
+    for (const page of outputDoc.getPages()) {
+      const { width: srcWidth, height: srcHeight } = page.getSize();
+      const scaleX = targetWidth / srcWidth;
+      const scaleY = targetHeight / srcHeight;
+      const scale = Math.min(scaleX, scaleY);
+
+      const scaledWidth = srcWidth * scale;
+      const scaledHeight = srcHeight * scale;
+      const x = (targetWidth - scaledWidth) / 2;
+      const y = (targetHeight - scaledHeight) / 2;
+
+      page.setSize(targetWidth, targetHeight);
+      page.scale(scale, scale);
+      page.translateContent(x, y);
+    }
+
+    const data = await outputDoc.save();
+
+    return {
+      data: new Uint8Array(data),
+      suggestedFileName: OUTPUT_FILENAME,
+    };
   }
 
   private async buildOutputFromPages(


### PR DESCRIPTION
## Summary
Add page size normalization that scales all pages to a uniform target size (A4 or US Letter) with proportional scaling and centered white padding.

## Changes
- Add `buildNormalizedPDF()` to `PDFOperationsService` — scales pages proportionally and pads to target dimensions
- Static `TARGET_SIZES` map for Letter and A4 dimensions
- Sidebar gains a "Normalize" dropdown (Off / US Letter / A4)
- When a target is selected, a "Download Normalized" button appears
- Unit tests for normalized build, empty pages, and progress reporting

## Testing
- [x] `bun run verify` passes (42 unit tests, type-check, lint, format, build)
- [ ] E2E on CI (Playwright)
- [ ] Manually verify normalized output has uniform page dimensions

## References
- Closes #58