### PR TITLE
feat: add PDF compress download

### DIFF
--- a/src/components/app/Editor.tsx
+++ b/src/components/app/Editor.tsx
@@ -287,6 +287,27 @@ export default function Editor() {
     }
   }
 
+  async function handleCompress(): Promise<void> {
+    if (isBusy()) return;
+    const totalPages = activePageCount();
+
+    setOperation("building");
+    setStatusMessage(`Compressing PDF... 0/${totalPages}`);
+
+    try {
+      const result = await pdfOperationsService.compressPDF(pages, ({ completed, total }) => {
+        setStatusMessage(`Compressing... ${completed}/${total}`);
+      });
+      downloadPDF(result);
+      dispatchToast("Compressed PDF download started.", "success");
+    } catch (err) {
+      console.error("Failed to compress PDF:", err);
+      dispatchToast("Failed to compress the PDF.", "error");
+    } finally {
+      setReadyStatus();
+    }
+  }
+
   // --- Drag and drop ---
 
   function handleDragStart(index: number, e: DragEvent): void {
@@ -428,6 +449,7 @@ export default function Editor() {
               onDelete={handleDeleteSelected}
               onExtract={handleExtract}
               onDownload={handleDownload}
+              onCompress={handleCompress}
               onAddPdf={handleAddPdf}
             />
 

--- a/src/components/app/EditorSidebar.tsx
+++ b/src/components/app/EditorSidebar.tsx
@@ -6,6 +6,7 @@ interface Props {
   onDelete: () => void;
   onExtract: () => void;
   onDownload: () => void;
+  onCompress: () => void;
   onAddPdf: (file: File) => void;
 }
 
@@ -101,6 +102,14 @@ export default function EditorSidebar(props: Props) {
           class="w-full bg-[#ff0000] text-white text-[11px] uppercase tracking-[0.15em] font-semibold py-3 border-none cursor-pointer hover:bg-[#111] transition-colors disabled:cursor-not-allowed disabled:opacity-60"
         >
           {props.busy ? "Working..." : "Download"}
+        </button>
+        <button
+          data-testid="editor-compress-button"
+          onClick={props.onCompress}
+          disabled={props.busy}
+          class="mt-2 w-full border border-[#111] bg-transparent py-2 text-[11px] font-semibold uppercase tracking-[0.15em] text-[#111] transition-colors hover:bg-[#111] hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Compress & Download
         </button>
       </div>
     </aside>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,5 +19,8 @@ export const OUTPUT_FILENAME = "quire-output.pdf";
 /** Default file name when extracting a page subset */
 export const EXTRACT_FILENAME = "quire-extract.pdf";
 
+/** Default file name for compressed PDF output */
+export const COMPRESSED_FILENAME = "quire-compressed.pdf";
+
 /** Title shown in the password prompt modal for encrypted PDFs */
 export const PASSWORD_MODAL_TITLE = "PASSWORD REQUIRED";

--- a/src/services/__tests__/pdf-operations-service.test.ts
+++ b/src/services/__tests__/pdf-operations-service.test.ts
@@ -10,11 +10,24 @@ const createMockPage = (overrides: Partial<PageState> = {}): PageState => ({
   ...overrides,
 });
 
+const mockCopiedPage = {
+  setRotation: vi.fn(),
+  getSize: vi.fn().mockReturnValue({ width: 612, height: 792 }),
+  setSize: vi.fn(),
+  scale: vi.fn(),
+  translateContent: vi.fn(),
+};
+
 const mockPDFDoc = {
-  copyPages: vi.fn().mockResolvedValue([{ setRotation: vi.fn() }]),
+  copyPages: vi.fn().mockResolvedValue([mockCopiedPage]),
   addPage: vi.fn(),
   save: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3])),
   getPageCount: vi.fn().mockReturnValue(1),
+  getPages: vi.fn().mockReturnValue([mockCopiedPage]),
+  setTitle: vi.fn(),
+  setAuthor: vi.fn(),
+  setSubject: vi.fn(),
+  setKeywords: vi.fn(),
 };
 
 const mockPDFDocument = {
@@ -158,6 +171,36 @@ describe("PDFOperationsService", () => {
       await expect(service.buildPDFFromSubset(pages, [])).rejects.toThrow(
         "No pages selected for extraction"
       );
+    });
+  });
+
+  describe("compressPDF", () => {
+    it("should create a compressed PDF", async () => {
+      const service = new PDFOperationsService();
+      const result = await service.compressPDF([createMockPage()]);
+
+      expect(result.data).toBeInstanceOf(Uint8Array);
+      expect(result.suggestedFileName).toBe("quire-compressed.pdf");
+    });
+
+    it("should throw when no active pages", async () => {
+      const service = new PDFOperationsService();
+      const deleted = createMockPage({ markedForDeletion: true });
+
+      await expect(service.compressPDF([deleted])).rejects.toThrow(
+        "No pages to include in the PDF"
+      );
+    });
+
+    it("should report progress", async () => {
+      const service = new PDFOperationsService();
+      const onProgress = vi.fn();
+      const pages = [createMockPage(), createMockPage({ id: "page-2", sourcePageNumber: 2 })];
+
+      await service.compressPDF(pages, onProgress);
+
+      expect(onProgress).toHaveBeenNthCalledWith(1, { completed: 1, total: 2 });
+      expect(onProgress).toHaveBeenNthCalledWith(2, { completed: 2, total: 2 });
     });
   });
 

--- a/src/services/pdf-operations-service.ts
+++ b/src/services/pdf-operations-service.ts
@@ -1,5 +1,5 @@
 import { PDFDocument, degrees } from "pdf-lib";
-import { EXTRACT_FILENAME, OUTPUT_FILENAME } from "../constants";
+import { COMPRESSED_FILENAME, EXTRACT_FILENAME, OUTPUT_FILENAME } from "../constants";
 import type {
   PageState,
   PDFOperationResult,
@@ -67,6 +67,52 @@ export class PDFOperationsService implements IPDFOperationsService {
       EXTRACT_FILENAME,
       onProgress
     );
+  }
+
+  /**
+   * Builds a compressed PDF by re-encoding with object streams.
+   *
+   * @param pages - The current editor page state to compress.
+   * @param onProgress - Optional callback invoked after each page is copied.
+   * @returns The compressed PDF bytes and a suggested download filename.
+   * @throws {Error} When there are no active pages to include in the output.
+   */
+  async compressPDF(
+    pages: PageState[],
+    onProgress?: (progress: PDFBuildProgress) => void
+  ): Promise<PDFOperationResult> {
+    const activePages = pages.filter((page) => !page.markedForDeletion);
+
+    if (activePages.length === 0) {
+      throw new Error("No pages to include in the PDF");
+    }
+
+    const outputDoc = await PDFDocument.create();
+
+    for (const [index, page] of activePages.entries()) {
+      const sourceDoc = await this.getOrLoadSourceDoc(page.sourceFile);
+      const [copiedPage] = await outputDoc.copyPages(sourceDoc, [page.sourcePageNumber - 1]);
+
+      if (page.rotation !== 0) {
+        copiedPage.setRotation(degrees(page.rotation));
+      }
+
+      outputDoc.addPage(copiedPage);
+      onProgress?.({ completed: index + 1, total: activePages.length });
+    }
+
+    // Strip metadata title/author/subject/keywords to reduce size
+    outputDoc.setTitle("");
+    outputDoc.setAuthor("");
+    outputDoc.setSubject("");
+    outputDoc.setKeywords([]);
+
+    const data = await outputDoc.save({ useObjectStreams: true });
+
+    return {
+      data: new Uint8Array(data),
+      suggestedFileName: COMPRESSED_FILENAME,
+    };
   }
 
   private async buildOutputFromPages(


### PR DESCRIPTION
## Summary
Add PDF compression using pdf-lib object streams and metadata stripping.

## Changes
- Add `compressPDF()` to `PDFOperationsService` — saves with `useObjectStreams: true` and strips metadata
- Add `COMPRESSED_FILENAME` constant
- Sidebar gains a "Compress & Download" button below the main Download button
- Unit tests for compress, empty pages, and progress reporting

## Testing
- [x] `bun run verify` passes (42 unit tests)
- [ ] E2E on CI
- [ ] Manually verify compressed output is smaller than standard download

## References
- Closes #23