### PR TITLE
feat: rebrand from Quire to Interleaf

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "Quire Dev Environment",
+  "name": "Interleaf Dev Environment",
   "build": {
     "dockerfile": "Dockerfile"
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,8 @@
-# Agent Instructions — Quire
+# Agent Instructions — Interleaf
 
 ## Overview
 
-- Quire is a client-side PDF editor for merge, extract, reorder, rotate, delete, and unlock flows.
+- Interleaf is a client-side PDF editor for merge, extract, reorder, rotate, delete, and unlock flows.
 - Keep PDF processing in the browser. Do not add uploads or server-side document handling.
 
 ## Stack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,12 +84,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Pasta's first usable baseline with PDF upload, viewing, rendering services, and drag-and-drop intake.
 
-[unreleased]: https://github.com/abijith-suresh/quire/compare/v0.6.1...HEAD
-[0.6.1]: https://github.com/abijith-suresh/quire/compare/v0.6.0...v0.6.1
-[0.6.0]: https://github.com/abijith-suresh/quire/compare/v0.5.0...v0.6.0
-[0.5.0]: https://github.com/abijith-suresh/quire/compare/v0.4.1...v0.5.0
-[0.4.1]: https://github.com/abijith-suresh/quire/compare/v0.4.0...v0.4.1
-[0.4.0]: https://github.com/abijith-suresh/quire/compare/v0.3.0...v0.4.0
-[0.3.0]: https://github.com/abijith-suresh/quire/compare/v0.2.0...v0.3.0
-[0.2.0]: https://github.com/abijith-suresh/quire/compare/v0.1.0...v0.2.0
-[0.1.0]: https://github.com/abijith-suresh/quire/releases/tag/v0.1.0
+[unreleased]: https://github.com/abijith-suresh/interleaf/compare/v0.6.1...HEAD
+[0.6.1]: https://github.com/abijith-suresh/interleaf/compare/v0.6.0...v0.6.1
+[0.6.0]: https://github.com/abijith-suresh/interleaf/compare/v0.5.0...v0.6.0
+[0.5.0]: https://github.com/abijith-suresh/interleaf/compare/v0.4.1...v0.5.0
+[0.4.1]: https://github.com/abijith-suresh/interleaf/compare/v0.4.0...v0.4.1
+[0.4.0]: https://github.com/abijith-suresh/interleaf/compare/v0.3.0...v0.4.0
+[0.3.0]: https://github.com/abijith-suresh/interleaf/compare/v0.2.0...v0.3.0
+[0.2.0]: https://github.com/abijith-suresh/interleaf/compare/v0.1.0...v0.2.0
+[0.1.0]: https://github.com/abijith-suresh/interleaf/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Quire
+# Interleaf
 
-Quire is a fully client-side PDF editor for the core tasks people reach for most: merge, extract, reorder, rotate, delete, and unlock. Every operation runs in your browser with `pdf-lib` and `pdf.js`, so your files never leave your device.
+Interleaf is a fully client-side PDF editor for the core tasks people reach for most: merge, extract, reorder, rotate, delete, and unlock. Every operation runs in your browser with `pdf-lib` and `pdf.js`, so your files never leave your device.
 
 ## Product Scope
 
@@ -68,8 +68,8 @@ tests/
 
 ## Release Notes
 
-- Current canonical domain target: `https://quire.page`
-- Current GitHub repository: `https://github.com/abijith-suresh/quire`
+- Current canonical domain target: `https://interleaf.page`
+- Current GitHub repository: `https://github.com/abijith-suresh/interleaf`
 - License: [MIT](./LICENSE)
 
 ## Contributing

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -5,7 +5,7 @@ import solid from "@astrojs/solid-js";
 // https://astro.build/config
 export default defineConfig({
   integrations: [solid()],
-  site: "https://quire.page",
+  site: "https://interleaf.page",
   vite: {
     plugins: [tailwindcss()],
     resolve: {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "quire",
+  "name": "interleaf",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "version": "0.6.1",

--- a/src/components/shared/Footer.astro
+++ b/src/components/shared/Footer.astro
@@ -13,7 +13,7 @@ const { base } = Astro.props;
   <div class="max-w-7xl mx-auto">
     <div class="grid grid-cols-1 md:grid-cols-[1fr_2fr] gap-12">
       <div>
-        <span class="font-display text-2xl text-primary">Quire</span>
+        <span class="font-display text-2xl text-primary">Interleaf</span>
         <p class="text-sm font-light text-muted mt-2">
           Client-side PDF editing.<br />No uploads. No servers.
         </p>
@@ -32,7 +32,7 @@ const { base } = Astro.props;
             >Changelog</a
           >
           <a
-            href="https://github.com/abijith-suresh/quire"
+            href="https://github.com/abijith-suresh/interleaf"
             target="_blank"
             rel="noopener"
             class="block text-sm text-body no-underline hover:text-primary transition-colors mb-2 link-slide"
@@ -73,7 +73,7 @@ const { base } = Astro.props;
       </div>
     </div>
     <div class="border-t border-border mt-12 pt-6 flex justify-center text-[0.65rem] text-muted">
-      <span>&copy; 2026 Quire</span>
+      <span>&copy; 2026 Interleaf</span>
     </div>
   </div>
 </footer>

--- a/src/components/shared/Nav.astro
+++ b/src/components/shared/Nav.astro
@@ -15,7 +15,9 @@ const links = [
 
 <nav class="border-b border-border px-6 md:px-16 lg:px-24" transition:persist>
   <div class="max-w-7xl mx-auto h-14 flex items-center justify-between">
-    <a href={base} class="font-display text-2xl text-primary no-underline tracking-wide">Quire</a>
+    <a href={base} class="font-display text-2xl text-primary no-underline tracking-wide"
+      >Interleaf</a
+    >
     <div class="flex items-center gap-6 md:gap-8">
       {
         links.map((link) => (

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -14,10 +14,10 @@ export const ROTATION_STEP = 90;
 export const TOAST_DISMISS_TIMEOUT_MS = 3000;
 
 /** Default file name for the merged/reordered PDF output */
-export const OUTPUT_FILENAME = "quire-output.pdf";
+export const OUTPUT_FILENAME = "interleaf-output.pdf";
 
 /** Default file name when extracting a page subset */
-export const EXTRACT_FILENAME = "quire-extract.pdf";
+export const EXTRACT_FILENAME = "interleaf-extract.pdf";
 
 /** Title shown in the password prompt modal for encrypted PDFs */
 export const PASSWORD_MODAL_TITLE = "PASSWORD REQUIRED";

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -33,7 +33,7 @@ const resolvedOgImage = ogImage ?? `${siteOrigin}${base}og/${slug}.png`;
     <link rel="canonical" href={canonicalURL} />
     {description && <meta name="description" content={description} />}
     <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="Quire" />
+    <meta property="og:site_name" content="Interleaf" />
     <meta property="og:title" content={title} />
     {description && <meta property="og:description" content={description} />}
     <meta property="og:url" content={canonicalURL} />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -23,8 +23,8 @@ const values = [
 ---
 
 <Layout
-  title="About — Quire"
-  description="Quire was built on one idea: every PDF operation should run in your browser. No accounts, no uploads, no servers. Open source and fully transparent."
+  title="About — Interleaf"
+  description="Interleaf was built on one idea: every PDF operation should run in your browser. No accounts, no uploads, no servers. Open source and fully transparent."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
     <Nav base={base} currentPage="about" />
@@ -40,7 +40,7 @@ const values = [
           <h1
             class="font-display text-[clamp(3rem,7vw,6rem)] leading-[0.9] text-primary animate-on-scroll stagger-1"
           >
-            Why Quire.
+            Why Interleaf.
           </h1>
         </div>
       </section>
@@ -51,8 +51,9 @@ const values = [
         >
           <div>
             <p class="text-body font-light leading-relaxed text-lg mb-6">
-              PDF tools shouldn't require uploading your documents to someone else's server. Quire
-              was built on a simple idea: every PDF operation can happen right in your browser.
+              PDF tools shouldn't require uploading your documents to someone else's server.
+              Interleaf was built on a simple idea: every PDF operation can happen right in your
+              browser.
             </p>
             <p class="text-body font-light leading-relaxed">
               No accounts. No subscriptions. No file size limits imposed by a server. Just open the
@@ -129,7 +130,7 @@ const values = [
           </h2>
           <div>
             <a
-              href="https://github.com/abijith-suresh/quire"
+              href="https://github.com/abijith-suresh/interleaf"
               target="_blank"
               rel="noopener"
               class="inline-block px-8 py-4 bg-accent text-white text-xs font-semibold uppercase tracking-[0.15em] no-underline hover:bg-primary transition-colors press-feedback"

--- a/src/pages/app.astro
+++ b/src/pages/app.astro
@@ -4,7 +4,7 @@ import Editor from "../components/app/Editor";
 ---
 
 <Layout
-  title="Quire — Editor"
+  title="Interleaf — Editor"
   description="Open your PDF and start editing. Merge, split, reorder, rotate, and delete pages — all client-side, nothing leaves your device."
 >
   <main data-page="editor" transition:animate="none">

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -62,8 +62,8 @@ function formatDate(date: string) {
 ---
 
 <Layout
-  title="Changelog — Quire"
-  description="A complete history of every Quire release derived from the canonical changelog."
+  title="Changelog — Interleaf"
+  description="A complete history of every Interleaf release derived from the canonical changelog."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
     <Nav base={base} />

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -9,7 +9,7 @@ const questions = [
   {
     num: "01",
     q: "How does client-side processing work?",
-    a: "Quire uses pdf-lib and pdf.js — JavaScript libraries that run entirely in your browser. When you upload a PDF, it's read into your browser's memory and processed locally. No data is sent to any server.",
+    a: "Interleaf uses pdf-lib and pdf.js — JavaScript libraries that run entirely in your browser. When you upload a PDF, it's read into your browser's memory and processed locally. No data is sent to any server.",
   },
   {
     num: "02",
@@ -19,7 +19,7 @@ const questions = [
   {
     num: "03",
     q: "Which browsers are supported?",
-    a: "Quire works in all modern browsers including Chrome, Firefox, Safari, and Edge. We recommend using the latest version for the best experience.",
+    a: "Interleaf works in all modern browsers including Chrome, Firefox, Safari, and Edge. We recommend using the latest version for the best experience.",
   },
   {
     num: "04",
@@ -28,30 +28,30 @@ const questions = [
   },
   {
     num: "05",
-    q: "Is Quire free to use?",
-    a: "Yes. Quire is completely free and open source. There are no premium tiers, no subscriptions, and no hidden costs.",
+    q: "Is Interleaf free to use?",
+    a: "Yes. Interleaf is completely free and open source. There are no premium tiers, no subscriptions, and no hidden costs.",
   },
   {
     num: "06",
     q: "Can I contribute to the project?",
-    a: "Absolutely. Quire is open source and hosted on GitHub. You can report issues, suggest features, or submit pull requests.",
+    a: "Absolutely. Interleaf is open source and hosted on GitHub. You can report issues, suggest features, or submit pull requests.",
   },
   {
     num: "07",
-    q: "Does Quire work offline?",
+    q: "Does Interleaf work offline?",
     a: "Once the page is loaded, most operations work without an internet connection. However, you need to be online to initially load the application.",
   },
   {
     num: "08",
     q: "What PDF operations are supported?",
-    a: "Quire supports merge, split, reorder, rotate, and delete operations. All operations are performed client-side.",
+    a: "Interleaf supports merge, split, reorder, rotate, and delete operations. All operations are performed client-side.",
   },
 ];
 ---
 
 <Layout
-  title="FAQ — Quire"
-  description="Answers to common questions about Quire: how client-side processing works, privacy, browser support, file size limits, and more."
+  title="FAQ — Interleaf"
+  description="Answers to common questions about Interleaf: how client-side processing works, privacy, browser support, file size limits, and more."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
     <Nav base={base} currentPage="faq" />

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -48,7 +48,7 @@ const features = [
 ---
 
 <Layout
-  title="Features — Quire"
+  title="Features — Interleaf"
   description="Merge, split, reorder, rotate, and delete PDFs. Five powerful operations, all running client-side in your browser."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ const base = import.meta.env.BASE_URL;
 ---
 
 <Layout
-  title="Quire - Client-Side PDF Editor"
+  title="Interleaf - Client-Side PDF Editor"
   description="Edit, merge, split, reorder, rotate, and delete PDF files entirely in your browser. No uploads, no servers, no privacy compromises."
 >
   <div class="page" transition:animate={contentSlide}>
@@ -18,7 +18,7 @@ const base = import.meta.env.BASE_URL;
         <div class="hero-grid">
           <div class="hero-left">
             <p class="hero-label">Client-side PDF editor</p>
-            <h1 class="hero-title">Quire</h1>
+            <h1 class="hero-title">Interleaf</h1>
             <div class="hero-tagline">
               <span class="red-bar"></span>
               <p class="hero-tagline-text">Edit, merge, split — all in your browser.</p>
@@ -98,7 +98,7 @@ const base = import.meta.env.BASE_URL;
         <div class="bottom-cta-inner">
           <h2 class="bottom-title">Start<br />editing.</h2>
           <div class="bottom-action">
-            <a href={`${base}app`} class="cta-filled press-feedback">Launch Quire</a>
+            <a href={`${base}app`} class="cta-filled press-feedback">Launch Interleaf</a>
           </div>
         </div>
       </section>

--- a/src/pages/og/[page].png.ts
+++ b/src/pages/og/[page].png.ts
@@ -6,7 +6,7 @@ import { Resvg } from "@resvg/resvg-js";
 
 const pages: Record<string, { title: string; description: string }> = {
   index: {
-    title: "Quire",
+    title: "Interleaf",
     description: "Edit, merge, split — all in your browser.",
   },
   app: {
@@ -31,11 +31,11 @@ const pages: Record<string, { title: string; description: string }> = {
   },
   changelog: {
     title: "Changelog",
-    description: "A complete history of every Quire release.",
+    description: "A complete history of every Interleaf release.",
   },
   faq: {
     title: "FAQ",
-    description: "Everything you need to know about Quire.",
+    description: "Everything you need to know about Interleaf.",
   },
 };
 
@@ -84,7 +84,7 @@ export const GET: APIRoute = async ({ params }) => {
                     letterSpacing: "0.15em",
                     textTransform: "uppercase",
                   },
-                  children: "QUIRE",
+                  children: "INTERLEAF",
                 },
               },
               {
@@ -180,7 +180,7 @@ export const GET: APIRoute = async ({ params }) => {
                     color: "#555",
                     letterSpacing: "0.05em",
                   },
-                  children: "quire.page",
+                  children: "interleaf.page",
                 },
               },
             ],

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -10,7 +10,7 @@ const sections = [
     num: "01",
     title: "No Data Collection",
     content:
-      "Quire does not collect, store, or transmit any personal data. We do not use analytics, tracking pixels, or any form of user monitoring.",
+      "Interleaf does not collect, store, or transmit any personal data. We do not use analytics, tracking pixels, or any form of user monitoring.",
   },
   {
     num: "02",
@@ -22,7 +22,7 @@ const sections = [
     num: "03",
     title: "No Cookies",
     content:
-      "Quire does not use cookies, local storage, or any other client-side storage mechanism to track users or store personal information.",
+      "Interleaf does not use cookies, local storage, or any other client-side storage mechanism to track users or store personal information.",
   },
   {
     num: "04",
@@ -34,7 +34,7 @@ const sections = [
     num: "05",
     title: "Open Source",
     content:
-      "Quire is fully open source. You can inspect the complete source code on GitHub to verify these privacy claims for yourself.",
+      "Interleaf is fully open source. You can inspect the complete source code on GitHub to verify these privacy claims for yourself.",
   },
   {
     num: "06",
@@ -46,8 +46,8 @@ const sections = [
 ---
 
 <Layout
-  title="Privacy Policy — Quire"
-  description="Quire collects no data, uses no cookies, and never uploads your files. Your documents stay in your browser. Always."
+  title="Privacy Policy — Interleaf"
+  description="Interleaf collects no data, uses no cookies, and never uploads your files. Your documents stay in your browser. Always."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
     <Nav base={base} />

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -10,44 +10,44 @@ const sections = [
     num: "01",
     title: "Acceptance of Terms",
     content:
-      "By accessing and using Quire, you agree to be bound by these terms. If you do not agree, please do not use the application.",
+      "By accessing and using Interleaf, you agree to be bound by these terms. If you do not agree, please do not use the application.",
   },
   {
     num: "02",
     title: "No Warranty",
     content:
-      'Quire is provided "as is" without warranty of any kind, express or implied. We make no guarantees regarding the accuracy, reliability, or completeness of PDF operations performed by the tool.',
+      'Interleaf is provided "as is" without warranty of any kind, express or implied. We make no guarantees regarding the accuracy, reliability, or completeness of PDF operations performed by the tool.',
   },
   {
     num: "03",
     title: "Limitation of Liability",
     content:
-      "In no event shall the authors or contributors be liable for any damages arising from the use or inability to use Quire, including but not limited to data loss or corruption of PDF files.",
+      "In no event shall the authors or contributors be liable for any damages arising from the use or inability to use Interleaf, including but not limited to data loss or corruption of PDF files.",
   },
   {
     num: "04",
     title: "Open Source License",
     content:
-      "Quire is open-source software. The source code is available on GitHub and is subject to its respective license terms. You are free to inspect, modify, and distribute the code in accordance with the license.",
+      "Interleaf is open-source software. The source code is available on GitHub and is subject to its respective license terms. You are free to inspect, modify, and distribute the code in accordance with the license.",
   },
   {
     num: "05",
     title: "Permitted Use",
     content:
-      "You may use Quire for any lawful purpose, including personal and commercial use. You are solely responsible for the content of the PDF files you process using the tool.",
+      "You may use Interleaf for any lawful purpose, including personal and commercial use. You are solely responsible for the content of the PDF files you process using the tool.",
   },
   {
     num: "06",
     title: "Changes to Terms",
     content:
-      "We reserve the right to modify these terms at any time. Changes will be reflected on this page. Continued use of Quire after changes constitutes acceptance of the updated terms.",
+      "We reserve the right to modify these terms at any time. Changes will be reflected on this page. Continued use of Interleaf after changes constitutes acceptance of the updated terms.",
   },
 ];
 ---
 
 <Layout
-  title="Terms of Service — Quire"
-  description="Simple, honest terms of service for Quire. Free to use for any lawful purpose. Open source. No warranty."
+  title="Terms of Service — Interleaf"
+  description="Simple, honest terms of service for Interleaf. Free to use for any lawful purpose. Open source. No warranty."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
     <Nav base={base} />

--- a/src/services/__tests__/pdf-operations-service.test.ts
+++ b/src/services/__tests__/pdf-operations-service.test.ts
@@ -47,7 +47,7 @@ describe("PDFOperationsService", () => {
       const result = await service.buildPDF(pages);
 
       expect(result.data).toBeInstanceOf(Uint8Array);
-      expect(result.suggestedFileName).toBe("quire-output.pdf");
+      expect(result.suggestedFileName).toBe("interleaf-output.pdf");
     });
 
     it("should handle multiple pages", async () => {
@@ -120,7 +120,7 @@ describe("PDFOperationsService", () => {
       const result = await service.buildPDFFromSubset(pages, [0]);
 
       expect(result.data).toBeInstanceOf(Uint8Array);
-      expect(result.suggestedFileName).toBe("quire-extract.pdf");
+      expect(result.suggestedFileName).toBe("interleaf-extract.pdf");
     });
 
     it("should report progress while extracting", async () => {

--- a/src/utils/__tests__/download.test.ts
+++ b/src/utils/__tests__/download.test.ts
@@ -7,7 +7,7 @@ vi.mock("file-saver", () => ({
 
 const mockPDFOperationResult: PDFOperationResult = {
   data: new Uint8Array([1, 2, 3, 4, 5]),
-  suggestedFileName: "quire-output.pdf",
+  suggestedFileName: "interleaf-output.pdf",
 };
 
 describe("download utility", () => {

--- a/src/utils/toast.ts
+++ b/src/utils/toast.ts
@@ -7,7 +7,7 @@ export interface ToastDetail {
   type: ToastType;
 }
 
-export const TOAST_EVENT_NAME = "quire:toast";
+export const TOAST_EVENT_NAME = "interleaf:toast";
 
 export function showToast(message: string, type: ToastType): void {
   document.dispatchEvent(

--- a/tests/e2e/core-app.spec.ts
+++ b/tests/e2e/core-app.spec.ts
@@ -43,7 +43,7 @@ test("rotates, deletes, extracts, and downloads", async ({ page }) => {
   const extractPromise = page.waitForEvent("download");
   await page.getByTestId("editor-extract-button").click();
   const extract = await extractPromise;
-  expect(extract.suggestedFilename()).toBe("quire-extract.pdf");
+  expect(extract.suggestedFilename()).toBe("interleaf-extract.pdf");
   await expect(page.getByTestId("editor-toast").last()).toContainText(
     "Extracted PDF download started."
   );
@@ -51,7 +51,7 @@ test("rotates, deletes, extracts, and downloads", async ({ page }) => {
   const downloadPromise = page.waitForEvent("download");
   await page.getByTestId("editor-download-button").click();
   const download = await downloadPromise;
-  expect(download.suggestedFilename()).toBe("quire-output.pdf");
+  expect(download.suggestedFilename()).toBe("interleaf-output.pdf");
 });
 
 test("adds another PDF to the current session", async ({ page }) => {
@@ -91,12 +91,12 @@ test("extracts and downloads after unlocking an encrypted PDF", async ({ page })
   const extractPromise = page.waitForEvent("download");
   await page.getByTestId("editor-extract-button").click();
   const extract = await extractPromise;
-  expect(extract.suggestedFilename()).toBe("quire-extract.pdf");
+  expect(extract.suggestedFilename()).toBe("interleaf-extract.pdf");
 
   const downloadPromise = page.waitForEvent("download");
   await page.getByTestId("editor-download-button").click();
   const download = await downloadPromise;
-  expect(download.suggestedFilename()).toBe("quire-output.pdf");
+  expect(download.suggestedFilename()).toBe("interleaf-output.pdf");
 });
 
 test("keeps the password prompt open after a wrong password and allows retry", async ({ page }) => {


### PR DESCRIPTION
## Summary

Rebrand the project from **Quire** to **Interleaf** following the GitHub repo rename.

### Changes

- Updated package name, site URL, and all repo references
- Updated page titles, meta tags, and OG image content across all routes
- Updated brand name in Nav, Footer, and layouts
- Updated copy in FAQ, About, Terms, Privacy, and Features pages
- Renamed default output/download filenames (`quire-output.pdf` → `interleaf-output.pdf`, `quire-extract.pdf` → `interleaf-extract.pdf`)
- Renamed toast event name (`quire:toast` → `interleaf:toast`)
- Updated test expectations and agent instructions
- Updated CHANGELOG comparison URLs

### Verification

- ✅ Type check passed
- ✅ Lint passed
- ✅ Format check passed
- ✅ All 39 tests passed (6 test suites)
- ✅ Build successful