### PR TITLE
refactor(astro): simplify static page chrome props

### DIFF
--- a/src/components/shared/Footer.astro
+++ b/src/components/shared/Footer.astro
@@ -1,9 +1,5 @@
 ---
-interface Props {
-  base: string;
-}
-
-const { base } = Astro.props;
+const base = import.meta.env.BASE_URL;
 ---
 
 <footer

--- a/src/components/shared/Nav.astro
+++ b/src/components/shared/Nav.astro
@@ -1,10 +1,10 @@
 ---
 interface Props {
-  base: string;
   currentPage?: string;
 }
 
-const { base, currentPage } = Astro.props;
+const { currentPage } = Astro.props;
+const base = import.meta.env.BASE_URL;
 
 const links = [
   { label: "Features", href: `${base}features`, key: "features" },

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,7 +3,6 @@ import Layout from "../layouts/Layout.astro";
 import Nav from "../components/shared/Nav.astro";
 import Footer from "../components/shared/Footer.astro";
 import { contentSlide } from "../utils/transitions";
-const base = import.meta.env.BASE_URL;
 
 const stack = [
   { name: "Astro", desc: "Static site framework" },
@@ -27,7 +26,7 @@ const values = [
   description="Interleaf was built on one idea: every PDF operation should run in your browser. No accounts, no uploads, no servers. Open source and fully transparent."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
-    <Nav base={base} currentPage="about" />
+    <Nav currentPage="about" />
 
     <main>
       <section class="px-6 md:px-16 lg:px-24 pt-24 pb-16 border-b border-border">
@@ -142,6 +141,6 @@ const values = [
       </section>
     </main>
 
-    <Footer base={base} />
+    <Footer />
   </div>
 </Layout>

--- a/src/pages/changelog.astro
+++ b/src/pages/changelog.astro
@@ -5,8 +5,6 @@ import Nav from "../components/shared/Nav.astro";
 import Footer from "../components/shared/Footer.astro";
 import { contentSlide } from "../utils/transitions";
 
-const base = import.meta.env.BASE_URL;
-
 type ReleaseSection = { title: string; items: string[] };
 type Release = { version: string; date: string; sections: ReleaseSection[] };
 
@@ -66,7 +64,7 @@ function formatDate(date: string) {
   description="A complete history of every Interleaf release derived from the canonical changelog."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
-    <Nav base={base} />
+    <Nav />
 
     <main>
       <section class="px-6 md:px-16 lg:px-24 pt-24 pb-16 border-b border-border">
@@ -120,6 +118,6 @@ function formatDate(date: string) {
       </section>
     </main>
 
-    <Footer base={base} />
+    <Footer />
   </div>
 </Layout>

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -3,7 +3,6 @@ import Layout from "../layouts/Layout.astro";
 import Nav from "../components/shared/Nav.astro";
 import Footer from "../components/shared/Footer.astro";
 import { contentSlide } from "../utils/transitions";
-const base = import.meta.env.BASE_URL;
 
 const questions = [
   {
@@ -54,7 +53,7 @@ const questions = [
   description="Answers to common questions about Interleaf: how client-side processing works, privacy, browser support, file size limits, and more."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
-    <Nav base={base} currentPage="faq" />
+    <Nav currentPage="faq" />
 
     <main>
       <section class="px-6 md:px-16 lg:px-24 pt-24 pb-16 border-b border-border">
@@ -95,6 +94,6 @@ const questions = [
       </section>
     </main>
 
-    <Footer base={base} />
+    <Footer />
   </div>
 </Layout>

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -3,6 +3,7 @@ import Layout from "../layouts/Layout.astro";
 import Nav from "../components/shared/Nav.astro";
 import Footer from "../components/shared/Footer.astro";
 import { contentSlide } from "../utils/transitions";
+
 const base = import.meta.env.BASE_URL;
 
 const features = [
@@ -52,7 +53,7 @@ const features = [
   description="Merge, split, reorder, rotate, and delete PDFs. Five powerful operations, all running client-side in your browser."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
-    <Nav base={base} currentPage="features" />
+    <Nav currentPage="features" />
 
     <main>
       <section class="px-6 md:px-16 lg:px-24 pt-24 pb-16 border-b border-border">
@@ -134,6 +135,6 @@ const features = [
       </section>
     </main>
 
-    <Footer base={base} />
+    <Footer />
   </div>
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ const base = import.meta.env.BASE_URL;
   description="Edit, merge, split, reorder, rotate, and delete PDF files entirely in your browser. No uploads, no servers, no privacy compromises."
 >
   <div class="page" transition:animate={contentSlide}>
-    <Nav base={base} currentPage="home" />
+    <Nav currentPage="home" />
     <main>
       <section class="hero">
         <div class="hero-grid">
@@ -104,7 +104,7 @@ const base = import.meta.env.BASE_URL;
       </section>
     </main>
 
-    <Footer base={base} />
+    <Footer />
   </div>
 </Layout>
 

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -3,7 +3,6 @@ import Layout from "../layouts/Layout.astro";
 import Nav from "../components/shared/Nav.astro";
 import Footer from "../components/shared/Footer.astro";
 import { contentSlide } from "../utils/transitions";
-const base = import.meta.env.BASE_URL;
 
 const sections = [
   {
@@ -50,7 +49,7 @@ const sections = [
   description="Interleaf collects no data, uses no cookies, and never uploads your files. Your documents stay in your browser. Always."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
-    <Nav base={base} />
+    <Nav />
 
     <main>
       <section class="px-6 md:px-16 lg:px-24 pt-24 pb-16 border-b border-border">
@@ -91,6 +90,6 @@ const sections = [
       </section>
     </main>
 
-    <Footer base={base} />
+    <Footer />
   </div>
 </Layout>

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -3,7 +3,6 @@ import Layout from "../layouts/Layout.astro";
 import Nav from "../components/shared/Nav.astro";
 import Footer from "../components/shared/Footer.astro";
 import { contentSlide } from "../utils/transitions";
-const base = import.meta.env.BASE_URL;
 
 const sections = [
   {
@@ -50,7 +49,7 @@ const sections = [
   description="Simple, honest terms of service for Interleaf. Free to use for any lawful purpose. Open source. No warranty."
 >
   <div class="font-body bg-white text-primary min-h-screen" transition:animate={contentSlide}>
-    <Nav base={base} />
+    <Nav />
 
     <main>
       <section class="px-6 md:px-16 lg:px-24 pt-24 pb-16 border-b border-border">
@@ -91,6 +90,6 @@ const sections = [
       </section>
     </main>
 
-    <Footer base={base} />
+    <Footer />
   </div>
 </Layout>


### PR DESCRIPTION
## Summary
Simplify the shared Astro page chrome by letting Nav and Footer read BASE_URL internally instead of threading it through every static page. This reduces page-level boilerplate while keeping routes and rendered markup behavior unchanged.

## Changes
- remove the base prop from shared static-site Nav and Footer components
- stop passing BASE_URL through static page frontmatter where it was only used for shared chrome
- keep page-local editor links unchanged where pages still need BASE_URL directly

## Testing
**Automated**
- [x] bun run verify passed
