### PR TITLE
docs: project alignment audit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,13 +28,23 @@
 - `src/services/`: PDF load, render, and manipulation logic
 - `src/pages/`: marketing, legal, editor, and OG routes
 - `src/utils/`: download, password prompt, toast, transitions, and helpers
-- `tests/__tests__/`: unit tests for services and controllers
+- `src/**/__tests__/`: unit tests co-located with source (services, controllers, utils)
 
 ## Hard Rules
 
 - Preserve the browser-only privacy model.
 - Keep editor behavior covered by unit tests.
 - Use the existing controller/service split instead of pushing business logic into page components.
+
+## Document Ownership
+
+- `README.md` — user-facing only. Product scope, stack, development quickstart.
+- `docs/CONTEXT.md` — product truth. Goals, non-goals, constraints, success criteria.
+- `docs/ARCHITECTURE.md` — technical truth. Architecture, data flow, design decisions.
+- `docs/CONTRIBUTING.md` — development workflow. Setup, conventions, testing, CI.
+- `AGENTS.md` — this file. Agent instructions and document ownership.
+
+When the product vision, architecture, or workflow changes, update the corresponding document. Keep these files as the single source of truth.
 
 ## Git And CI
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,57 +2,55 @@
 
 ## Overview
 
-- Interleaf is a client-side PDF editor for merge, extract, reorder, rotate, delete, and unlock flows.
-- Keep PDF processing in the browser. Do not add uploads or server-side document handling.
+Interleaf is a client-side PDF editor for merge, extract, reorder, rotate, delete, and unlock flows. PDF processing stays in the browser. See `docs/CONTEXT.md` for the full product truth.
 
 ## Stack
 
-- Astro 6
-- SolidJS editor UI
-- Tailwind CSS v4
-- TypeScript
-- Bun
-- Vitest
+- Astro 6, SolidJS, Tailwind CSS v4, TypeScript, Bun, Vitest
+- pdf-lib (manipulation), pdf.js (rendering)
 
-## Commands
+## Quick Commands
 
-- Install deps: `bun install`
-- Dev server: `bun run dev`
-- Quality gate: `bun run verify`
-- Individual steps: `bun run type-check`, `bun run lint`, `bun run format:check`, `bun run test`, `bun run build`
+```sh
+bun install          # Install deps
+bun run dev          # Dev server at localhost:4321
+bun run verify       # Full quality gate (type-check, lint, format, test, build)
+```
+
+Full workflow details in `docs/CONTRIBUTING.md`.
 
 ## Project Map
 
-- `src/components/app/`: editor UI, tiles, canvases, sidebar, and uploader
-- `src/controllers/`: editor page-state helpers and orchestration utilities
-- `src/services/`: PDF load, render, and manipulation logic
-- `src/pages/`: marketing, legal, editor, and OG routes
-- `src/utils/`: download, password prompt, toast, transitions, and helpers
-- `src/**/__tests__/`: unit tests co-located with source (services, controllers, utils)
+```
+src/components/app/    SolidJS editor UI (Editor, Sidebar, PageGrid, PageTile, PageCanvas, Uploader)
+src/components/shared/ Astro chrome (Nav, Footer, BottomCTA, PageHeader, NumberedRow)
+src/controllers/       Page-state helpers (no DOM, no rendering)
+src/services/          PDF load, render, and build (PDFService, PDFOperationsService)
+src/pages/             Marketing, legal, editor, and OG routes
+src/utils/             Download, password prompt, toast, transitions
+src/**/__tests__/      Co-located unit tests
+```
+
+Full architecture in `docs/ARCHITECTURE.md`.
 
 ## Hard Rules
 
-- Preserve the browser-only privacy model.
-- Keep editor behavior covered by unit tests.
-- Use the existing controller/service split instead of pushing business logic into page components.
+- **Never add server-side PDF handling.** All processing stays in the browser.
+- **Never add uploads.** Files are read into browser memory only.
+- **Never add analytics, tracking, or cookies.** Privacy is absolute.
+- **Keep business logic in services/controllers**, not in page components.
+- **Cover editor behavior with unit tests.**
+
+Full constraints in `docs/CONTEXT.md`.
 
 ## Document Ownership
 
-- `README.md` — user-facing only. Product scope, stack, development quickstart.
-- `docs/CONTEXT.md` — product truth. Goals, non-goals, constraints, success criteria.
-- `docs/ARCHITECTURE.md` — technical truth. Architecture, data flow, design decisions.
-- `docs/CONTRIBUTING.md` — development workflow. Setup, conventions, testing, CI.
-- `AGENTS.md` — this file. Agent instructions and document ownership.
+| File                   | Purpose                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| `README.md`            | User-facing. Product scope, stack, dev quickstart.              |
+| `docs/CONTEXT.md`      | Product truth. Goals, non-goals, constraints, success criteria. |
+| `docs/ARCHITECTURE.md` | Technical truth. Architecture, data flow, design decisions.     |
+| `docs/CONTRIBUTING.md` | Dev workflow. Setup, conventions, testing, CI, git process.     |
+| `AGENTS.md`            | This file. Agent instructions and document ownership.           |
 
 When the product vision, architecture, or workflow changes, update the corresponding document. Keep these files as the single source of truth.
-
-## Git And CI
-
-- Branch from the latest `main` before starting changes.
-- Never commit directly to `main`.
-- Commit and PR titles must use Conventional Commits: `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`.
-- Before push, run `bun run verify`.
-- `pre-commit` runs `lint-staged`, `commit-msg` runs `commitlint`, and `pre-push` runs `bun run verify`.
-- CI enforces `quality` and `pr-title` checks on pull requests.
-
-- Squash merge is the expected merge strategy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/README.md
+++ b/README.md
@@ -53,14 +53,15 @@ src/
   components/app/      Solid editor UI and page tiles/canvases
   components/shared/   Shared marketing-site chrome
   controllers/         Editor page-state helpers and orchestration logic
-  fonts/               Self-hosted application assets
   layouts/             Shared page layout and SEO tags
   pages/               Marketing, legal, editor, and OG routes
   services/            PDF load, render, and build services
   styles/              Global styles and motion primitives
   utils/               Download, password, toast, and transition helpers
-tests/
-  unit/                Unit tests for services, controllers, and utilities
+docs/
+  CONTEXT.md           Product truth, goals, and constraints
+  ARCHITECTURE.md      Technical architecture and design decisions
+  CONTRIBUTING.md      Development setup and workflow
 ```
 
 ## Release Notes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,146 @@
+# Architecture — Interleaf
+
+## High-Level Overview
+
+```
+Browser
+├── Astro 6 (static site + SSR for OG images)
+│   ├── Marketing pages (.astro)
+│   │   ├── Home, Features, About, FAQ, Privacy, Terms
+│   │   └── Shared chrome: Nav, Footer, BottomCTA, PageHeader, NumberedRow
+│   └── Editor page (/app)
+│       └── SolidJS island (client:only)
+└── SolidJS Editor (client-side only)
+    ├── PDFService — load, cache, render PDFs
+    ├── PDFOperationsService — build, extract output PDFs
+    ├── Controller — page state helpers
+    └── Components — Editor, Sidebar, PageGrid, PageTile, PageCanvas, Uploader
+```
+
+## Stack
+
+| Layer               | Technology                 |
+| ------------------- | -------------------------- |
+| Site framework      | Astro 6                    |
+| Editor UI           | SolidJS                    |
+| CSS                 | Tailwind CSS v4            |
+| PDF rendering       | pdf.js (Mozilla)           |
+| PDF manipulation    | pdf-lib                    |
+| OG image generation | Satori + Resvg             |
+| Package manager     | Bun                        |
+| Tests               | Vitest (jsdom environment) |
+| Language            | TypeScript                 |
+| Linting             | ESLint + Prettier          |
+| CI                  | GitHub Actions             |
+
+## Directory Structure
+
+```
+src/
+  components/
+    app/                  SolidJS editor components
+      Editor.tsx           Root editor — state, operations, layout
+      EditorPageCanvas.tsx Lazy-rendered page thumbnail (IntersectionObserver)
+      EditorPageGrid.tsx   Scrollable grid of page tiles
+      EditorPageTile.tsx   Drag-and-drop page tile with selection state
+      EditorSidebar.tsx    Desktop sidebar: actions, upload, export
+      EditorUploader.tsx   Initial upload dropzone
+    shared/               Astro shared chrome
+      BottomCTA.astro
+      Footer.astro
+      Nav.astro
+      NumberedRow.astro
+      PageHeader.astro
+  controllers/            Page-state logic (no DOM, no rendering)
+    editor-page-state.ts  createPageStates, toggleSelection, remapAfterMove
+  layouts/
+    Layout.astro          Base HTML shell, meta tags, OG, fonts
+  pages/
+    index.astro           Homepage
+    app.astro             Editor entry point
+    features.astro        Feature list
+    about.astro           About, tech stack, values
+    faq.astro             FAQ
+    privacy.astro         Privacy policy
+    terms.astro           Terms of service
+    og/[page].png.ts      Dynamic OG image endpoint
+  scripts/
+    scroll-animations.ts  IntersectionObserver scroll reveals
+  services/
+    pdf-service.ts        PDF load/unlock/render (PDFDocument + pdf.js)
+    pdf-operations-service.ts  Build/extract output PDFs (pdf-lib)
+  styles/
+    global.css            Tailwind tokens, animations, shared utilities
+    editor.css            Editor-only page tile styles
+  types/
+    interfaces.ts         PageState, PDFOperationResult, errors
+  utils/
+    download.ts           Blob-based file download
+    password-prompt.ts    Imperative DOM modal for PDF unlock
+    toast.ts              Custom event-based toast system
+    transitions.ts        Astro View Transition config
+  constants.ts            Magic numbers and strings
+```
+
+## Data Flow
+
+### PDF Loading
+
+```
+User drops/selects file
+  → Editor.loadPdfFile()
+    → PDFService.loadPDF(file)
+      → File.arrayBuffer()
+      → PDFDocument.load(buffer)     [pdf-lib]
+      → pdfjsLib.getDocument(data)   [pdf.js]
+      → Cache in documentCache Map<File, LoadedPDFRecord>
+      → Set activeFile
+    → Editor creates PageState[] via controller
+```
+
+### Thumbnail Rendering
+
+```
+PageTile comes into viewport
+  → IntersectionObserver fires
+  → PDFService.renderPage(file, pageNum, canvas, scale, rotation)
+    → Get cached pdfjsDocument for file
+    → page.getViewport({ scale, rotation })
+    → page.render({ canvasContext, viewport }).promise
+```
+
+### PDF Export (Download/Extract)
+
+```
+User clicks Download or Extract
+  → PDFOperationsService.buildPDF(pages) or buildPDFFromSubset(pages, indices)
+    → Filter out deleted pages
+    → For each page: getOrLoadSourceDoc → copyPages → setRotation → addPage
+    → outputDoc.save() → Uint8Array
+  → downloadPDF(result)
+    → Blob → ObjectURL → hidden <a> click
+```
+
+## Key Design Decisions
+
+### File-keyed caching
+
+PDFService and PDFOperationsService both cache by `File` reference. This allows multi-file sessions where thumbnails from different source PDFs render independently. The cache is cleared on session reset and component cleanup.
+
+### Co-located tests
+
+Tests live alongside their source at `src/**/__tests__/`. Vitest is configured with `jsdom` environment and globals enabled. Test files match `*.test.ts`.
+
+### Controller/service split
+
+- **Services**: Pure logic (PDF loading, rendering, building) — no DOM, no UI.
+- **Controllers**: Stateless helper functions for page-state mutations — no side effects.
+- **Components**: UI only, delegate to services and controllers.
+
+### Imperative password prompt
+
+The password modal is built imperatively (vanilla DOM) rather than as a SolidJS component. This avoids conditional rendering inside the editor tree and keeps the prompt available during any loading state.
+
+### Toast system
+
+Toasts use a `CustomEvent` bus (`interleaf:toast`). Utilities dispatch events; the Editor component listens and renders. This decouples toast triggers from the UI layer.

--- a/docs/CONTEXT.md
+++ b/docs/CONTEXT.md
@@ -1,0 +1,43 @@
+# Context — Interleaf
+
+## Why Interleaf Exists
+
+Interleaf is a browser-based PDF utility that replaces ad-infested, login-walled tools like iLovePDF. Every operation runs client-side. No uploads, no accounts, no tracking.
+
+## Target Users
+
+1. **The maintainer** — daily PDF tasks without privacy compromises.
+2. **Anyone** who needs to edit PDFs and values privacy.
+3. Serves as a **portfolio piece** — demonstrating clean product design and engineering.
+
+## Goals
+
+- Core PDF operations working reliably: merge, extract, reorder, rotate, delete.
+- Unlock password-protected PDFs without any server involvement.
+- Superior UI/UX compared to existing PDF tools — clean, fast, intuitive.
+- Complete privacy guarantee — files never leave the browser.
+- Present as a proper product with marketing pages, privacy policy, and values.
+
+## Non-Goals / Hard Constraints
+
+| Constraint   | Detail                                             |
+| ------------ | -------------------------------------------------- |
+| No accounts  | No registration, no login, no user identity.       |
+| No ads       | No advertising of any kind.                        |
+| No analytics | No tracking, no telemetry, no data collection.     |
+| No servers   | No uploads, no server-side processing, no backend. |
+| No cookies   | No client-side storage for tracking.               |
+| No tracking  | Files, behavior, and usage are never observed.     |
+
+These constraints are absolute and non-negotiable.
+
+## Success Criteria
+
+1. All core operations work correctly without bugs or data corruption.
+2. The editor handles edge cases gracefully (encrypted PDFs, large files, mixed sources).
+3. Users trust the privacy claim — verifiable by inspecting network activity.
+4. The product feels polished and professional as both a utility and a portfolio piece.
+
+## Version Philosophy
+
+Interleaf lives in `0.x.x` version space indefinitely. There is no target `1.0.0` milestone. Features are added incrementally as needs arise. This is a living project, not a release-driven one.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing — Interleaf
+
+## Prerequisites
+
+- [Bun](https://bun.sh) (version matches `.bun-version`)
+- Node.js 24+ (for Astro compatibility in CI)
+
+## Setup
+
+```sh
+bun install
+bun run dev        # http://localhost:4321
+```
+
+## Quality Gate
+
+Before pushing, run:
+
+```sh
+bun run verify
+```
+
+This runs, in order:
+
+1. `type-check` — `astro check && tsc --noEmit`
+2. `lint` — `eslint .`
+3. `format:check` — `prettier --check .`
+4. `test` — `vitest run`
+5. `build` — `astro build`
+
+Individual steps:
+
+```sh
+bun run type-check
+bun run lint
+bun run format:check
+bun run test
+bun run build
+```
+
+Fix formatting and lint automatically:
+
+```sh
+bun run lint:fix
+bun run format
+```
+
+## Git Workflow
+
+1. Branch from latest `main`.
+2. Write changes following existing patterns.
+3. Run `bun run verify` — this runs automatically on `pre-push`.
+4. Commit using [Conventional Commits](https://www.conventionalcommits.org/): `feat`, `fix`, `docs`, `refactor`, `chore`, `test`, `ci`.
+5. Push and open a PR against `main`.
+
+### Hooks
+
+| Hook         | Action                                           |
+| ------------ | ------------------------------------------------ |
+| `pre-commit` | Runs `lint-staged` on staged files               |
+| `commit-msg` | Validates commit message format via `commitlint` |
+| `pre-push`   | Runs `bun run verify`                            |
+
+### CI
+
+CI runs on every PR to `main`:
+
+- **quality**: Full verify pass (type-check, lint, format:check, test, build)
+- **pr-title**: Enforces Conventional Commit format on PR titles
+- **dependency-review**: Audits dependency changes
+
+## Code Conventions
+
+### Hard Rules
+
+- **Never add server-side PDF handling.** All processing stays in the browser.
+- **Never add uploads.** Files are read into browser memory only.
+- **Never add analytics, tracking, or cookies.** Privacy is absolute.
+- **Keep business logic in services/controllers**, not in page components.
+
+### Architecture
+
+- **Services** (`src/services/`): PDF loading, rendering, and manipulation. No DOM, no UI.
+- **Controllers** (`src/controllers/`): Pure stateless helpers for page-state logic.
+- **Components** (`src/components/app/`): SolidJS editor UI. Delegate to services/controllers.
+- **Shared components** (`src/components/shared/`): Astro chrome for marketing pages.
+- **Utils** (`src/utils/`): Browser utilities (download, password prompt, toast, transitions).
+- **Types** (`src/types/`): Shared interfaces and error classes.
+
+### Testing
+
+Tests are co-located with source: `src/**/__tests__/*.test.ts`.
+
+```sh
+bun run test         # Run once
+bun run test:watch   # Watch mode
+```
+
+Cover services, controllers, and utilities. Use Vitest with `jsdom` environment.
+
+### Styling
+
+- Tailwind CSS v4 with CSS-first `@theme` tokens in `global.css`.
+- Editor-specific styles in `editor.css`.
+- Use existing utility classes and CSS custom properties.
+- Follow the Swiss-industrial aesthetic: minimal, typographic, high contrast.
+
+## Adding Features
+
+1. Open an issue first for discussion if the feature is substantial.
+2. Implement in the appropriate layer (service, controller, component).
+3. Add tests for new logic.
+4. Update documentation if the feature changes product scope.
+5. Keep the privacy model intact.
+
+## Documentation
+
+- `README.md` — user-facing only.
+- `docs/CONTEXT.md` — product truth (goals, non-goals, constraints).
+- `docs/ARCHITECTURE.md` — technical truth.
+- `docs/CONTRIBUTING.md` — this file.
+- `AGENTS.md` — agent instructions and document ownership.

--- a/src/pages/app.astro
+++ b/src/pages/app.astro
@@ -6,7 +6,7 @@ import "../styles/editor.css";
 
 <Layout
   title="Interleaf — Editor"
-  description="Open your PDF and start editing. Merge, split, reorder, rotate, and delete pages — all client-side, nothing leaves your device."
+  description="Open your PDF and start editing. Merge, extract, reorder, rotate, delete, and unlock pages — all client-side, nothing leaves your device."
 >
   <main data-page="editor" transition:animate="none">
     <Editor client:only="solid-js" />

--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -45,7 +45,7 @@ const questions = [
   {
     num: "08",
     q: "What PDF operations are supported?",
-    a: "Interleaf supports merge, split, reorder, rotate, and delete operations. All operations are performed client-side.",
+    a: "Interleaf supports merge, extract, reorder, rotate, delete, and unlock operations. All operations are performed client-side.",
   },
 ];
 ---

--- a/src/pages/features.astro
+++ b/src/pages/features.astro
@@ -22,7 +22,7 @@ const features = [
   },
   {
     num: "02",
-    title: "Split",
+    title: "Extract",
     desc: "Extract selected pages into a new PDF.",
     details: ["Select any subset of pages", "Exports a separate PDF", "Preserves your page order"],
   },
@@ -48,12 +48,22 @@ const features = [
     desc: "Remove unwanted pages cleanly from any PDF.",
     details: ["Click to select pages", "Bulk deletion"],
   },
+  {
+    num: "06",
+    title: "Unlock",
+    desc: "Open password-protected PDFs without any server involvement.",
+    details: [
+      "In-browser password prompt",
+      "Handles owner and user passwords",
+      "No data leaves your device",
+    ],
+  },
 ];
 ---
 
 <Layout
   title="Features — Interleaf"
-  description="Merge, split, reorder, rotate, and delete PDFs. Five powerful operations, all running client-side in your browser."
+  description="Merge, extract, reorder, rotate, delete, and unlock PDFs. Six powerful operations, all running client-side in your browser."
 >
   <div class="page-wrapper" transition:animate={contentSlide}>
     <Nav currentPage="features" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,7 +11,7 @@ const base = import.meta.env.BASE_URL;
 
 <Layout
   title="Interleaf - Client-Side PDF Editor"
-  description="Edit, merge, split, reorder, rotate, and delete PDF files entirely in your browser. No uploads, no servers, no privacy compromises."
+  description="Edit, merge, extract, reorder, rotate, delete, and unlock PDF files entirely in your browser. No uploads, no servers, no privacy compromises."
 >
   <div class="page-wrapper" transition:animate={contentSlide}>
     <Nav currentPage="home" />
@@ -23,7 +23,7 @@ const base = import.meta.env.BASE_URL;
             <h1 class="hero-title">Interleaf</h1>
             <div class="hero-tagline">
               <span class="red-bar"></span>
-              <p class="hero-tagline-text">Edit, merge, split — all in your browser.</p>
+              <p class="hero-tagline-text">Edit, merge, extract — all in your browser.</p>
             </div>
           </div>
           <div class="hero-right">
@@ -41,7 +41,7 @@ const base = import.meta.env.BASE_URL;
       <section class="section py-16">
         <div class="features-header animate-on-scroll">
           <h2 class="features-title">Features</h2>
-          <p class="features-subtitle">Five core operations, zero compromises.</p>
+          <p class="features-subtitle">Six core operations, zero compromises.</p>
         </div>
 
         <div class="border-t-2 border-primary">
@@ -55,7 +55,7 @@ const base = import.meta.env.BASE_URL;
               },
               {
                 num: "02",
-                title: "Split",
+                title: "Extract",
                 text: "Extract specific pages into separate PDF files.",
                 accent: false,
               },
@@ -75,6 +75,12 @@ const base = import.meta.env.BASE_URL;
                 num: "05",
                 title: "Delete",
                 text: "Remove unwanted pages cleanly from any PDF.",
+                accent: false,
+              },
+              {
+                num: "06",
+                title: "Unlock",
+                text: "Open password-protected PDFs with an in-browser prompt.",
                 accent: true,
               },
             ].map((f, i) => (


### PR DESCRIPTION
## Summary
Project alignment audit comparing intended product vision against implementation. Adds missing project documentation, fixes stale paths, removes redundant agent file, standardizes "Extract" terminology, and promotes "Unlock" to a visible marketing feature.

## Changes
- Add `docs/CONTEXT.md` — product truth, goals, non-goals, constraints, success criteria
- Add `docs/ARCHITECTURE.md` — technical architecture, data flow, design decisions
- Add `docs/CONTRIBUTING.md` — development workflow, setup, conventions, CI
- Fix `AGENTS.md` stale test directory path and add document ownership section
- Fix `README.md` project structure to reflect co-located tests and docs/
- Remove duplicate `CLAUDE.md`
- Rename "Split" to "Extract" on homepage, features page, FAQ, and app meta
- Add "Unlock" as a sixth core operation to homepage, features page, FAQ, and app meta

## Testing
**Automated**
- [x] `bun run verify` passed (37 tests, type-check, lint, format, build)

**Manual**
- [x] Verify homepage features section shows 6 operations with "Extract" label
- [x] Verify features page lists Unlock as the sixth operation
- [x] Verify FAQ mentions unlock in supported operations list