### PR TITLE
ci: trigger dependabot re-evaluation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,7 @@ updates:
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "Asia/Kolkata"
     open-pull-requests-limit: 10
@@ -26,8 +25,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:30"
       timezone: "Asia/Kolkata"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Temporarily change schedule to daily to trigger Dependabot to check for updates and create fresh PRs for both minor/patch and major version bumps.