### PR TITLE
fix: replace invalid dependabot auto-merge config with actions workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        auto-merge: "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -42,4 +41,3 @@ updates:
         update-types:
           - "minor"
           - "patch"
-        auto-merge: "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+
+    # Only act on Dependabot PRs in this repo.
+    if: >
+      github.event.pull_request.user.login == 'dependabot[bot]'
+      && github.repository == 'abijith-suresh/interleaf'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v3
+        with:
+          github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}"
+
+      # Skip major bumps — they deserve human review.
+      - name: Enable auto-merge for patch and minor updates
+        if: >
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}


### PR DESCRIPTION
## Problem

The `auto-merge: "*"` key under `groups` in `.github/dependabot.yml` is **not a valid Dependabot configuration option**. GitHubs built-in config validation rejects it on every PR.

## Changes

### 1. Remove invalid config from `.github/dependabot.yml`

Delete `auto-merge: "*"` from both the `bun` and `github-actions` update groups.

### 2. New workflow: `.github/workflows/dependabot-auto-merge.yml`

A dedicated workflow that:
- Triggers on `pull_request`
- Scopes to Dependabot PRs only
- Uses `dependabot/fetch-metadata@v3` to detect update type
- Enables auto-merge for **patch and minor** updates via `gh pr merge --auto --merge`
- Uses `DEPENDABOT_AUTOMERGE_PAT` (fine-grained PAT with `Pull requests: Read and Write`)

Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions
