### PR TITLE
ci: revert dependabot schedule to weekly Monday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,9 @@ updates:
   - package-ecosystem: "bun"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "21:30"
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
       timezone: "Asia/Kolkata"
     open-pull-requests-limit: 10
     labels:
@@ -25,8 +26,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
-      time: "22:00"
+      interval: "weekly"
+      day: "monday"
+      time: "09:30"
       timezone: "Asia/Kolkata"
     open-pull-requests-limit: 5
     labels:


### PR DESCRIPTION
Dependabot has run and created PRs (#171-#177). Reverting schedule back to weekly Monday to avoid daily runs.