### PR TITLE
fix: use GITHUB_TOKEN instead of PAT in auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v3
         with:
-          github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
 
       # Skip major bumps — they deserve human review.
       - name: Enable auto-merge for patch and minor updates
@@ -31,4 +31,4 @@ jobs:
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The DEPENDABOT_AUTOMERGE_PAT secret doesn't exist, causing the  check to fail on all PRs.\n\nFix: Use  instead, which is automatically provided and has the same write permissions (contents: write, pull-requests: write).