### PR TITLE
fix: restore DEPENDABOT_AUTOMERGE_PAT in auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,7 +21,7 @@ jobs:
         id: metadata
         uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v3
         with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}"
 
       # Skip major bumps — they deserve human review.
       - name: Enable auto-merge for patch and minor updates
@@ -31,4 +31,4 @@ jobs:
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}


### PR DESCRIPTION
Revert the GITHUB_TOKEN change - the DEPENDABOT_AUTOMERGE_PAT secret does exist.\n\nKeep the --squash fix (the repo only allows squash merges).