### PR TITLE
ci: bump dependabot/fetch-metadata SHA to latest v3

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7 # v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3
         with:
           github-token: "${{ secrets.DEPENDABOT_AUTOMERGE_PAT }}"
 


### PR DESCRIPTION
Update the pinned SHA for dependabot/fetch-metadata action to the latest v3 commit.\n\n(Equivalent to PR #172 but without workflow scope issues.)