### PR TITLE
chore: switch typecheck from astro check to tsc --noEmit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
-    "type-check": "astro check && tsc --noEmit",
+    "type-check": "astro sync && tsc --noEmit",
     "lint": "biome lint .",
     "lint:fix": "biome lint --write .",
     "format": "biome format --write .",


### PR DESCRIPTION
TS 7 removes the compiler API that `astro check` relies on. Switch the type-check script to `astro sync && tsc --noEmit` (same pattern proven in tailory/unwrapped).

Local `bun run verify` passes.